### PR TITLE
Add KAKEN integration via CiNii Research Projects API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,30 @@ DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO
 
 現在のバージョン（Phase 1）では、APIからのデータ取得・マッピング・編集UIが実装されています。
 
-### OpenAlex API Key の設定
+### API Key の設定
 
-OpenAlex APIは、APIキーなしでの利用回数に制限があります。継続的に利用する場合は、APIキーの設定を推奨します。
-
-1. [OpenAlex API設定ページ](https://openalex.org/settings/api) からAPIキーを取得
-2. `make_jc_importer.html` をテキストエディタで開く
-3. ファイル冒頭付近の `CONFIG` 定数を探し、`YOUR_API_KEY` を取得したキーに置き換える
+`make_jc_importer.html` をテキストエディタで開き、ファイル冒頭付近の `CONFIG` 定数にAPIキーを設定してください。
 
 ```js
 const CONFIG = {
-    API_KEY: "ここに取得したAPIキーを貼り付け",
+    OpenAlex_API_KEY: "ここにOpenAlex APIキーを貼り付け",
+    CiNii_API_KEY: "ここにCiNii APIキーを貼り付け",
 };
 ```
 
-APIキーが未設定の場合、ページ上部に警告メッセージが表示されます。未設定でも利用可能ですが、利用回数の制限を超えるとデータ取得時にエラーが表示されます。
+#### OpenAlex API Key（必須）
+
+OpenAlex APIは、APIキーなしでの利用回数に制限があります。継続的に利用する場合は、APIキーの設定を推奨します。
+
+- [OpenAlex API設定ページ](https://openalex.org/settings/api) からAPIキーを取得してください。
+- 未設定の場合、ページ上部に警告メッセージが表示されます。未設定でも利用可能ですが、利用回数の制限を超えるとデータ取得時にエラーが表示されます。
+
+#### CiNii API Key（任意）
+
+CiNii APIキーを設定すると、JSPS（日本学術振興会）が助成機関に含まれる場合に、CiNii Research Projects API を通じて科研費の課題名（日英）とKAKEN課題ページURLを自動取得します。
+
+- [CiNiiウェブAPI 利用登録](https://support.nii.ac.jp/ja/cinii/api/developer) からAPIキーを取得してください。
+- 未設定の場合、KAKEN連携はスキップされ、Crossrefの助成情報のみが表示されます。
 
 ## 機能
 
@@ -44,6 +53,7 @@ APIキーが未設定の場合、ページ上部に警告メッセージが表�
 - JATS XML 形式のDescription(内容記述)からタグの除去
 - Crossref と OpenAlex の著者情報マッチング（姓名一致 → インデックスフォールバック）
 - 空フィールドのみの表示
+- KAKEN連携：JSPS助成の科研費課題名（日英）・課題ページURL自動取得（CiNii Research Projects API）
 
 ### Phase 2
 
@@ -53,7 +63,7 @@ APIキーが未設定の場合、ページ上部に警告メッセージが表�
 ## 技術スタック
 
 - HTML5 / CSS3 / JavaScript（依存ライブラリなし、単一HTMLファイル）
-- 外部API: [Crossref](https://api.crossref.org/), [OpenAlex](https://api.openalex.org/), [ROR](https://ror.org/)
+- 外部API: [Crossref](https://api.crossref.org/), [OpenAlex](https://api.openalex.org/), [ROR](https://ror.org/), [CiNii Research](https://cir.nii.ac.jp/)
 
 ## ディレクトリ構成
 
@@ -85,6 +95,7 @@ APIキーが未設定の場合、ページ上部に警告メッセージが表�
 
 | 日付 | 内容 |
 |------|------|
+| 2026-02-18 | KAKEN連携：JSPS助成時にCiNii Research APIから科研費課題名・URLを自動取得（[#2](https://github.com/tzhaya/jc-import-file-maker/issues/2), [#7](https://github.com/tzhaya/jc-import-file-maker/issues/7)） |
 | 2026-02-17 | DOI登録機関（RA）判定機能を追加し、Crossref/JaLC/その他で処理を分岐（[#5](https://github.com/tzhaya/jc-import-file-maker/issues/5)） |
 | 2026-02-17 | 同一助成機関から複数awardがある場合に各awardごとにエントリを生成するよう修正 |
 | 2026-02-17 | OpenAlex API Key設定機能を追加（[#1](https://github.com/tzhaya/jc-import-file-maker/issues/1)） |

--- a/docs/Implementation_KAKEN.md
+++ b/docs/Implementation_KAKEN.md
@@ -1,0 +1,319 @@
+# KAKEN連携 実装計画（Issue #2 + #7）
+
+## Context
+
+Crossref の funder 情報に JSPS（日本学術振興会）が含まれる場合、CiNii Research Projects API を使って科研費の課題名（日英）と KAKEN 課題ページ URL を取得し、WEKO の助成情報フィールドに自動入力する。
+
+---
+
+## 対象ファイル
+
+| ファイル | 操作 |
+|---------|------|
+| `make_jc_importer.html` | **修正**（CONFIG変更、API取得関数追加、マッピング修正） |
+
+---
+
+## 変更箇所の概要
+
+```
+make_jc_importer.html
+├── CONFIG定数 (~L403-407)          … キー名変更
+├── fetchOpenAlex() (~L784-797)     … CONFIG参照先変更
+├── 新規: fetchKaken()              … CiNii Research API呼び出し
+├── buildFunders() (~L1028-1062)    … async化、CiNiiデータ反映
+├── mapToItemType() (~L1064-1308)   … async化（buildFunders await）
+├── fetchCrossrefData() (~L847-880) … mapToItemType await対応
+└── APIキー未設定警告 (~L2463-2465) … CONFIG参照先変更
+```
+
+---
+
+## 実装ステップ
+
+### Step 1: CONFIG定数の変更（~L403-407）
+
+**変更前:**
+```js
+const CONFIG = {
+    API_KEY: "YOUR_API_KEY",
+};
+```
+
+**変更後:**
+```js
+const CONFIG = {
+    // OpenAlex APIキー（必須）
+    // https://openalex.org/settings/api からご自身のキーを取得して貼り付けてください
+    OpenAlex_API_KEY: "YOUR_OpenAlex_API_KEY",
+
+    // CiNii APIキー（任意）
+    // CiNiiウェブAPI 利用登録 https://support.nii.ac.jp/ja/cinii/api/developer で取得したキーを貼り付けてください
+    CiNii_API_KEY: "YOUR_CiNii_API_KEY",
+};
+```
+
+### Step 2: fetchOpenAlex() の CONFIG参照先変更（~L787-788）
+
+`CONFIG.API_KEY` → `CONFIG.OpenAlex_API_KEY` に変更。判定条件のデフォルト値も合わせて変更。
+
+**変更前:**
+```js
+if (CONFIG.API_KEY && CONFIG.API_KEY !== 'YOUR_API_KEY') {
+    url += `?api_key=${encodeURIComponent(CONFIG.API_KEY)}`;
+}
+```
+
+**変更後:**
+```js
+if (CONFIG.OpenAlex_API_KEY && CONFIG.OpenAlex_API_KEY !== 'YOUR_OpenAlex_API_KEY') {
+    url += `?api_key=${encodeURIComponent(CONFIG.OpenAlex_API_KEY)}`;
+}
+```
+
+### Step 3: fetchKaken() の新規追加（~L847付近、fetchCrossrefData の前に挿入）
+
+CiNii Research Projects API を呼び出し、課題名（日英）と課題 URL を返す関数を新規作成する。
+
+```js
+// ===== 3.5 CiNii Research KAKEN API =====
+async function fetchKaken(awardNumber) {
+  // JP プレフィックス除去
+  const projectId = awardNumber.replace(/^JP/i, '');
+  const appid = encodeURIComponent(CONFIG.CiNii_API_KEY);
+
+  // 日本語・英語タイトルを並列取得
+  const [jaResp, enResp] = await Promise.all([
+    fetch(`https://cir.nii.ac.jp/opensearch/v2/projects?appid=${appid}&format=json&projectId=${encodeURIComponent(projectId)}`),
+    fetch(`https://cir.nii.ac.jp/opensearch/v2/projects?appid=${appid}&format=json&projectId=${encodeURIComponent(projectId)}&lang=en`),
+  ]);
+
+  if (!jaResp.ok || !enResp.ok) return null;
+
+  const jaData = await jaResp.json();
+  const enData = await enResp.json();
+
+  if (!jaData.items?.length) return null;
+
+  const jaTitle = jaData.items[0].title || '';
+  const enTitle = enData.items?.[0]?.title || '';
+  const kakenUrl = jaData.items[0]['dc:source']?.[0]?.['@id'] || '';
+
+  // 日英タイトルが同一の場合は英語タイトルなし
+  const titles = [];
+  if (jaTitle) {
+    titles.push({ subitem_award_title: jaTitle, subitem_award_title_language: 'ja' });
+  }
+  if (enTitle && enTitle !== jaTitle) {
+    titles.push({ subitem_award_title: enTitle, subitem_award_title_language: 'en' });
+  }
+
+  return { titles, kakenUrl };
+}
+```
+
+**ポイント:**
+- 日英リクエストを `Promise.all` で並列化
+- `items` が空の場合は `null` を返す（呼び出し元で空フィールド維持）
+- 日英タイトルが同一なら英語タイトルを除外
+
+### Step 4: buildFunders() の async化（~L1028-1062）
+
+`buildFunders` を `async` にし、JSPS funder の場合に `fetchKaken()` を呼び出す。
+
+**変更前:**
+```js
+function buildFunders(crFunders) {
+  return (crFunders || []).flatMap(f => {
+    ...
+    const buildEntry = (awardNum) => {
+      ...
+      obj.subitem_award_numbers = {
+        subitem_award_number: awardNum,
+        subitem_award_number_type: '',
+        subitem_award_uri: '',
+      };
+      obj.subitem_award_titles = [];
+      return obj;
+    };
+
+    if (awards.length === 0) return [buildEntry('')];
+    return awards.map(aw => buildEntry(aw));
+  });
+}
+```
+
+**変更後:**
+```js
+async function buildFunders(crFunders) {
+  const JSPS_DOI = '10.13039/501100001691';
+  const isKakenEnabled = CONFIG.CiNii_API_KEY
+                      && CONFIG.CiNii_API_KEY !== 'YOUR_CiNii_API_KEY';
+
+  const entries = await Promise.all((crFunders || []).map(async (f) => {
+    const name      = f.name  || '';
+    const funderDoi = f.DOI   || '';
+    const awards    = f.award || [];
+
+    // JSPS判定: DOI一致 かつ CiNii_API_KEY設定済み
+    const isJsps = isKakenEnabled && funderDoi === JSPS_DOI;
+
+    const buildEntry = async (awardNum) => {
+      const obj = {};
+      obj.subitem_funder_names = name
+        ? [{ subitem_funder_name: name, subitem_funder_name_language: 'en' }]
+        : [];
+
+      if (funderDoi) {
+        obj.subitem_funder_identifiers = {
+          subitem_funder_identifier:      `https://doi.org/${funderDoi}`,
+          subitem_funder_identifier_type: 'Crossref Funder',
+        };
+      } else {
+        obj.subitem_funder_identifiers = {
+          subitem_funder_identifier: '',
+          subitem_funder_identifier_type: '',
+        };
+      }
+
+      // KAKEN連携: JSPS かつ award番号ありの場合
+      let kakenResult = null;
+      if (isJsps && awardNum) {
+        try {
+          kakenResult = await fetchKaken(awardNum);
+        } catch (e) {
+          console.warn(`KAKEN取得失敗 (${awardNum}):`, e.message);
+        }
+      }
+
+      obj.subitem_award_numbers = {
+        subitem_award_number:      awardNum,
+        subitem_award_number_type: '',
+        subitem_award_uri:         kakenResult?.kakenUrl || '',
+      };
+
+      obj.subitem_award_titles = kakenResult?.titles || [];
+      return obj;
+    };
+
+    if (awards.length === 0) return [await buildEntry('')];
+    return Promise.all(awards.map(aw => buildEntry(aw)));
+  }));
+
+  return entries.flat();
+}
+```
+
+**ポイント:**
+- `flatMap` → `Promise.all` + `map` + `flat()` に変更（async対応）
+- JSPS判定: `funderDoi === '10.13039/501100001691'` かつ `CiNii_API_KEY` 設定済み
+- KAKEN取得失敗時は `console.warn` のみで Crossref データを保持
+- 各 funder の KAKEN リクエストを並列実行
+
+### Step 5: mapToItemType() の async化（~L1064-1308）
+
+`buildFunders` が async になったため、`mapToItemType` も async 化する。
+
+**変更前:**
+```js
+function mapToItemType(crJson, oaJson, rorMap) {
+  ...
+  item_30002_funding_reference21: buildFunders(crJson.funder),
+  ...
+}
+```
+
+**変更後:**
+```js
+async function mapToItemType(crJson, oaJson, rorMap) {
+  ...
+  item_30002_funding_reference21: await buildFunders(crJson.funder),
+  ...
+}
+```
+
+変更は2箇所のみ:
+1. `function` → `async function`
+2. `buildFunders(crJson.funder)` → `await buildFunders(crJson.funder)`
+
+### Step 6: fetchCrossrefData() の mapToItemType 呼び出し修正（~L877）
+
+`mapToItemType` が async になったため `await` を追加する。
+
+**変更前:**
+```js
+const metadata = mapToItemType(crJson, oaJson, rorMap);
+```
+
+**変更後:**
+```js
+const metadata = await mapToItemType(crJson, oaJson, rorMap);
+```
+
+`fetchCrossrefData` は既に async 関数のため、`await` を追加するだけでよい。
+
+### Step 7: APIキー未設定警告の変更（~L2463-2465）
+
+`CONFIG.API_KEY` → `CONFIG.OpenAlex_API_KEY` に変更。
+
+**変更前:**
+```js
+if (!CONFIG.API_KEY || CONFIG.API_KEY === 'YOUR_API_KEY') {
+  document.getElementById('apikey-warning').style.display = 'block';
+}
+```
+
+**変更後:**
+```js
+if (!CONFIG.OpenAlex_API_KEY || CONFIG.OpenAlex_API_KEY === 'YOUR_OpenAlex_API_KEY') {
+  document.getElementById('apikey-warning').style.display = 'block';
+}
+```
+
+---
+
+## 処理フロー
+
+```
+fetchData()
+  └→ fetchCrossrefData(doi)
+       ├→ fetchCrossref(doi)      ─┐
+       ├→ fetchOpenAlex(doi)      ─┤ 並列
+       │                           ↓
+       ├→ fetchAllRorData(oaJson)
+       │
+       └→ mapToItemType(crJson, oaJson, rorMap)    ← async化
+            └→ buildFunders(crJson.funder)          ← async化
+                 ├→ JSPS判定 (funder.DOI === "10.13039/501100001691")
+                 ├→ fetchKaken(awardNumber)          ← 新規
+                 │    ├→ CiNii API (langなし)  ─┐
+                 │    └→ CiNii API (lang=en)   ─┤ 並列
+                 │                               ↓
+                 │    └→ { titles, kakenUrl }
+                 └→ subitem_award_titles / subitem_award_uri にセット
+```
+
+---
+
+## エラーハンドリング方針
+
+| シナリオ | 挙動 |
+|---------|------|
+| CiNii_API_KEY 未設定 | KAKEN連携をスキップ（Crossrefデータのみ） |
+| JSPS以外の funder | KAKEN連携をスキップ（従来通り） |
+| award番号が空 | KAKEN連携をスキップ |
+| CiNii API がエラー応答 | `console.warn` で警告、Crossrefデータを保持 |
+| `items` が空配列 | CiNii由来フィールドを空のまま |
+| 日英タイトルが同一 | 英語タイトルを除外（日本語のみ） |
+
+---
+
+## テスト計画
+
+| テストケース | 入力DOI | 期待結果 |
+|---|---|---|
+| JSPS助成あり | `10.1016/j.advnut.2025.100480` | JSPS funderのaward番号でKAKEN連携が発動、課題名・URLが入力される |
+| JSPS助成なし | 任意の非JSPS DOI | 従来通りの動作（助成情報にCiNiiフィールドなし） |
+| CiNii_API_KEY未設定 | 任意 | KAKEN連携スキップ、従来通りの動作 |
+| 存在しない課題番号 | JSPS funderで無効な番号 | CiNii由来フィールドが空のまま |
+| 空フィールド表示 | 「空の入力フィールド」ボタン | エラーなく表示される |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -16,6 +16,7 @@ make_jc_importer.html
     -   Crossref API (`https://api.crossref.org/works/`)
     -   OpenAlex API (`https://api.openalex.org/works/`)
     -   ROR API (`https://api.ror.org/v2/organizations/`)
+    -   CiNii Research Projects API (`https://cir.nii.ac.jp/opensearch/v2/projects`)
        
 **メタデータ構造定義**
 - `ItemType.json` ただし、要素から `title_i18n_temp` は除く。 
@@ -333,12 +334,22 @@ ItemType.json には複数レベルのネスト構造を持つフィールドが
 - **Level 2**:
   - `subitem_funder_names[]` - 複数言語による助成機関名
   - `subitem_funder_identifiers` - 助成機関識別子 (単一)
-  - `subitem_funding_streams[]` - 複数プログラム名 
+  - `subitem_funding_streams[]` - 複数プログラム名
   - `subitem_award_titles[]` - 複数言語による研究課題名
 
 **要件**:
 - 複数言語バージョンの助成機関名・課題名をサポート
 - アコーディオンUIで複数プログラム情報を管理
+
+**KAKEN連携（CiNii Research Projects API）**:
+- Crossref の funder 情報に JSPS（日本学術振興会、funder DOI: `10.13039/501100001691`）が含まれる場合、CiNii Research Projects API を使って科研費の課題名と KAKEN 課題ページ URL を自動取得する
+- CiNii APIキー（`CONFIG.CiNii_API_KEY`）が設定されている場合のみ有効
+- award番号から `JP` プレフィックスを除去して CiNii API の `projectId` パラメータに使用
+- 日本語・英語の課題名を並列取得し、`subitem_award_titles[]` に設定
+  - 日英タイトルが同一の場合は日本語のみ設定
+- KAKEN 課題ページ URL を `subitem_award_uri` に設定
+- CiNii API がエラーの場合は警告のみ出力し、Crossref データを保持（フォールバック）
+- CiNii APIキー未設定、JSPS以外の funder、award番号が空の場合はKAKEN連携をスキップ
 
 ### 3. 会議記述フィールド
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -403,7 +403,11 @@
 const CONFIG = {
     // OpenAlex APIキー（必須）
     // https://openalex.org/settings/api からご自身のキーを取得して貼り付けてください
-    API_KEY: "YOUR_API_KEY",
+    OpenAlex_API_KEY: "YOUR_OpenAlex_API_KEY",
+
+    // CiNii APIキー（任意）
+    // CiNiiウェブAPI 利用登録 https://support.nii.ac.jp/ja/cinii/api/developer で取得したキーを貼り付けてください
+    CiNii_API_KEY: "YOUR_CiNii_API_KEY",
 };
 
 // ===== 除外フィールドリスト =====
@@ -784,8 +788,8 @@ async function fetchCrossref(doi) {
 // ===== 3.2 OpenAlex API =====
 async function fetchOpenAlex(doi) {
   let url = `https://api.openalex.org/works/doi:${encodeURIComponent(doi)}`;
-  if (CONFIG.API_KEY && CONFIG.API_KEY !== 'YOUR_API_KEY') {
-    url += `?api_key=${encodeURIComponent(CONFIG.API_KEY)}`;
+  if (CONFIG.OpenAlex_API_KEY && CONFIG.OpenAlex_API_KEY !== 'YOUR_OpenAlex_API_KEY') {
+    url += `?api_key=${encodeURIComponent(CONFIG.OpenAlex_API_KEY)}`;
   }
   const resp = await fetch(url);
   if (!resp.ok) {
@@ -844,7 +848,42 @@ async function fetchAllRorData(oaJson) {
   return rorMap;
 }
 
-// ===== 3.5 Crossref DOI データ取得 =====
+// ===== 3.5 CiNii Research KAKEN API =====
+async function fetchKaken(awardNumber) {
+  // JP プレフィックス除去
+  const projectId = awardNumber.replace(/^JP/i, '');
+  const appid = encodeURIComponent(CONFIG.CiNii_API_KEY);
+
+  // 日本語・英語タイトルを並列取得
+  const [jaResp, enResp] = await Promise.all([
+    fetch(`https://cir.nii.ac.jp/opensearch/v2/projects?appid=${appid}&format=json&projectId=${encodeURIComponent(projectId)}`),
+    fetch(`https://cir.nii.ac.jp/opensearch/v2/projects?appid=${appid}&format=json&projectId=${encodeURIComponent(projectId)}&lang=en`),
+  ]);
+
+  if (!jaResp.ok || !enResp.ok) return null;
+
+  const jaData = await jaResp.json();
+  const enData = await enResp.json();
+
+  if (!jaData.items?.length) return null;
+
+  const jaTitle = jaData.items[0].title || '';
+  const enTitle = enData.items?.[0]?.title || '';
+  const kakenUrl = jaData.items[0]['dc:source']?.[0]?.['@id'] || '';
+
+  // 日英タイトルが同一の場合は英語タイトルなし
+  const titles = [];
+  if (jaTitle) {
+    titles.push({ subitem_award_title: jaTitle, subitem_award_title_language: 'ja' });
+  }
+  if (enTitle && enTitle !== jaTitle) {
+    titles.push({ subitem_award_title: enTitle, subitem_award_title_language: 'en' });
+  }
+
+  return { titles, kakenUrl };
+}
+
+// ===== 3.6 Crossref DOI データ取得 =====
 async function fetchCrossrefData(doi) {
   // Crossref + OpenAlex を並列取得
   const [crJson, oaJson] = await Promise.all([
@@ -874,12 +913,12 @@ async function fetchCrossrefData(doi) {
   document.getElementById('info-bar').style.display = 'flex';
 
   // マッピング → レンダリング
-  const metadata = mapToItemType(crJson, oaJson, rorMap);
+  const metadata = await mapToItemType(crJson, oaJson, rorMap);
   showHints = true;
   renderAll(metadata);
 }
 
-// ===== 3.6 メイン取得フロー =====
+// ===== 3.7 メイン取得フロー =====
 async function fetchData() {
   showError('');
   const rawDoi = document.getElementById('doi-input').value.trim();
@@ -909,7 +948,7 @@ async function fetchData() {
   }
 }
 
-// ===== 3.7 空値テスト表示 =====
+// ===== 3.8 空値テスト表示 =====
 function showEmptyFields() {
   showError('');
   showHints = false;
@@ -1025,13 +1064,20 @@ function buildAuthors(crAuthors, oaAuthorships, rorMap) {
 }
 
 // ===== 4.4 助成情報マッピング =====
-function buildFunders(crFunders) {
-  return (crFunders || []).flatMap(f => {
+async function buildFunders(crFunders) {
+  const JSPS_DOI = '10.13039/501100001691';
+  const isKakenEnabled = CONFIG.CiNii_API_KEY
+                      && CONFIG.CiNii_API_KEY !== 'YOUR_CiNii_API_KEY';
+
+  const entries = await Promise.all((crFunders || []).map(async (f) => {
     const name      = f.name  || '';
     const funderDoi = f.DOI   || '';
     const awards    = f.award || [];
 
-    const buildEntry = (awardNum) => {
+    // JSPS判定: DOI一致 かつ CiNii_API_KEY設定済み
+    const isJsps = isKakenEnabled && funderDoi === JSPS_DOI;
+
+    const buildEntry = async (awardNum) => {
       const obj = {};
       obj.subitem_funder_names = name
         ? [{ subitem_funder_name: name, subitem_funder_name_language: 'en' }]
@@ -1046,23 +1092,35 @@ function buildFunders(crFunders) {
         obj.subitem_funder_identifiers = { subitem_funder_identifier: '', subitem_funder_identifier_type: '' };
       }
 
+      // KAKEN連携: JSPS かつ award番号ありの場合
+      let kakenResult = null;
+      if (isJsps && awardNum) {
+        try {
+          kakenResult = await fetchKaken(awardNum);
+        } catch (e) {
+          console.warn(`KAKEN取得失敗 (${awardNum}):`, e.message);
+        }
+      }
+
       obj.subitem_award_numbers = {
         subitem_award_number:      awardNum,
         subitem_award_number_type: '',
-        subitem_award_uri:         '',
+        subitem_award_uri:         kakenResult?.kakenUrl || '',
       };
 
-      obj.subitem_award_titles = []; // Crossref に課題名なし
+      obj.subitem_award_titles = kakenResult?.titles || [];
       return obj;
     };
 
-    if (awards.length === 0) return [buildEntry('')];
-    return awards.map(aw => buildEntry(aw));
-  });
+    if (awards.length === 0) return [await buildEntry('')];
+    return Promise.all(awards.map(aw => buildEntry(aw)));
+  }));
+
+  return entries.flat();
 }
 
 // ===== 4.1 メインマッピング関数 =====
-function mapToItemType(crJson, oaJson, rorMap) {
+async function mapToItemType(crJson, oaJson, rorMap) {
   const doi        = crJson.DOI || '';
   const pubDate    = getPubDate(crJson);
   const isOa       = oaJson.open_access?.is_oa   || false;
@@ -1259,7 +1317,7 @@ function mapToItemType(crJson, oaJson, rorMap) {
     item_30002_geolocation20: [],
 
     // ----- 助成情報 -----
-    item_30002_funding_reference21: buildFunders(crJson.funder),
+    item_30002_funding_reference21: await buildFunders(crJson.funder),
 
     // ----- 収録物識別子 -----
     item_30002_source_identifier22: sourceIdentifiers,
@@ -2460,7 +2518,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 });
 
 // ===== APIキー未設定警告 =====
-if (!CONFIG.API_KEY || CONFIG.API_KEY === 'YOUR_API_KEY') {
+if (!CONFIG.OpenAlex_API_KEY || CONFIG.OpenAlex_API_KEY === 'YOUR_OpenAlex_API_KEY') {
   document.getElementById('apikey-warning').style.display = 'block';
 }
 </script>

--- a/samples/cir.nii.ac.jp_19KK0341_en.json
+++ b/samples/cir.nii.ac.jp_19KK0341_en.json
@@ -1,0 +1,66 @@
+{
+  "@context": {
+    "@vocab": "http://purl.org/rss/1.0/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "prism": "http://prismstandard.org/namespaces/basic/2.0/",
+    "ndl": "http://ndl.go.jp/dcndl/terms",
+    "opensearch": "http://a9.com/-/spec/opensearch/1.1/",
+    "cir": "https://cir.nii.ac.jp/schema/1.0/",
+    "@language": "en"
+  },
+  "@id": "https://cir.nii.ac.jp/opensearch/v2/projects?format=json&projectId=19KK0341&lang=en",
+  "@type": "channel",
+  "title": "CiNii Research projects - json 19KK0341 en",
+  "description": "CiNii Research projects - json 19KK0341 en",
+  "link": {
+    "@id": "https://cir.nii.ac.jp/opensearch/v2/projects?format=json&projectId=19KK0341&lang=en"
+  },
+  "dc:date": "2026-02-18T21:08:58.753+09:00",
+  "opensearch:totalResults": 1,
+  "opensearch:startIndex": 1,
+  "opensearch:itemsPerPage": 1,
+  "items": [
+    {
+      "@id": "https://cir.nii.ac.jp/crid/1040848250614322432",
+      "@type": "item",
+      "title": "Evaluation of food environment and dietary guidelines in rural Madagascar",
+      "link": {
+        "@id": "https://cir.nii.ac.jp/crid/1040848250614322432"
+      },
+      "dc:creator": [
+        "Shiratori Sakiko"
+      ],
+      "dc:type": "Project",
+      "description": "マダガスカルの食事はコメの消費に偏っており、栄養不足や栄養バランスの不均衡がみられる。消費者の嗜好や行動に注目し栄養改善のモチベーションを探る基課題に対し、本国際共同研究では、実際に消費している食品をベースとして栄養改善に貢献する食生活指針を策定することを目的とする。つまり現在の食環境の特性を示し、栄養素供給の過不足を同定し、建設的な解決策を導く。各国・地域に固有の食環境に注目し、発育阻害の軽減に取り組む研究者と共同研究を行うことで、食環境評価の精度向上や効率化がみこめる。",
+      "dc:identifier": [
+        {
+          "@type": "cir:KAKEN",
+          "@value": "19KK0341"
+        },
+        {
+          "@type": "cir:JGN",
+          "@value": "JP19KK0341"
+        },
+        {
+          "@type": "cir:URI",
+          "@value": "https://kaken.nii.ac.jp/grant/KAKENHI-PROJECT-19KK0341/"
+        }
+      ],
+      "dc:subject": [
+        "栄養改善",
+        "食環境",
+        "マダガスカル",
+        "食生活指針",
+        "開発途上地域"
+      ],
+      "dc:source": [
+        {
+          "@id": "https://kaken.nii.ac.jp/grant/KAKENHI-PROJECT-19KK0341/",
+          "dc:title": "KAKEN"
+        }
+      ]
+    }
+  ]
+}

--- a/samples/cir.nii.ac.jp_19KK0341_ja.json
+++ b/samples/cir.nii.ac.jp_19KK0341_ja.json
@@ -1,0 +1,66 @@
+{
+  "@context": {
+    "@vocab": "http://purl.org/rss/1.0/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "prism": "http://prismstandard.org/namespaces/basic/2.0/",
+    "ndl": "http://ndl.go.jp/dcndl/terms",
+    "opensearch": "http://a9.com/-/spec/opensearch/1.1/",
+    "cir": "https://cir.nii.ac.jp/schema/1.0/",
+    "@language": "ja"
+  },
+  "@id": "https://cir.nii.ac.jp/opensearch/v2/projects?format=json&projectId=19KK0341",
+  "@type": "channel",
+  "title": "CiNii Research projects - json 19KK0341",
+  "description": "CiNii Research projects - json 19KK0341",
+  "link": {
+    "@id": "https://cir.nii.ac.jp/opensearch/v2/projects?format=json&projectId=19KK0341"
+  },
+  "dc:date": "2026-02-18T21:08:57.274+09:00",
+  "opensearch:totalResults": 1,
+  "opensearch:startIndex": 1,
+  "opensearch:itemsPerPage": 1,
+  "items": [
+    {
+      "@id": "https://cir.nii.ac.jp/crid/1040848250614322432",
+      "@type": "item",
+      "title": "マダガスカル農村部における食環境の評価と食生活指針",
+      "link": {
+        "@id": "https://cir.nii.ac.jp/crid/1040848250614322432"
+      },
+      "dc:creator": [
+        "白鳥 佐紀子"
+      ],
+      "dc:type": "Project",
+      "description": "マダガスカルの食事はコメの消費に偏っており、栄養不足や栄養バランスの不均衡がみられる。消費者の嗜好や行動に注目し栄養改善のモチベーションを探る基課題に対し、本国際共同研究では、実際に消費している食品をベースとして栄養改善に貢献する食生活指針を策定することを目的とする。つまり現在の食環境の特性を示し、栄養素供給の過不足を同定し、建設的な解決策を導く。各国・地域に固有の食環境に注目し、発育阻害の軽減に取り組む研究者と共同研究を行うことで、食環境評価の精度向上や効率化がみこめる。",
+      "dc:identifier": [
+        {
+          "@type": "cir:KAKEN",
+          "@value": "19KK0341"
+        },
+        {
+          "@type": "cir:JGN",
+          "@value": "JP19KK0341"
+        },
+        {
+          "@type": "cir:URI",
+          "@value": "https://kaken.nii.ac.jp/grant/KAKENHI-PROJECT-19KK0341/"
+        }
+      ],
+      "dc:subject": [
+        "栄養改善",
+        "食環境",
+        "マダガスカル",
+        "食生活指針",
+        "開発途上地域"
+      ],
+      "dc:source": [
+        {
+          "@id": "https://kaken.nii.ac.jp/grant/KAKENHI-PROJECT-19KK0341/",
+          "dc:title": "KAKEN"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- JSPS（日本学術振興会）が助成機関に含まれる場合、CiNii Research Projects API から科研費の課題名（日英）と KAKEN 課題ページ URL を自動取得し、助成情報フィールドに入力
- `CONFIG.API_KEY` を `CONFIG.OpenAlex_API_KEY` にリネームし、新たに `CONFIG.CiNii_API_KEY`（任意）を追加
- `fetchKaken()` 関数を新規追加、`buildFunders()` / `mapToItemType()` を async 化

## Changes
- `make_jc_importer.html`: CONFIG変更、fetchKaken()追加、buildFunders/mapToItemType async化、APIキー警告更新
- `README.md`: API Key設定セクション更新（OpenAlex/CiNii両方）、変更履歴追記
- `docs/requirements.md`: CiNii Research API追加、KAKEN連携要件追記
- `docs/worklog.md`: KAKEN連携実装記録追加
- `docs/Implementation_KAKEN.md`: 実装計画書（新規）
- `samples/cir.nii.ac.jp_19KK0341_*.json`: CiNii APIサンプルデータ（日英）

## Test plan
- [x] DOI `10.1016/j.advnut.2025.100480` で JSPS 助成の課題名（日本語のみ）と KAKEN URL が入力されること
- [x] DOI `10.1002/advs.202512896` で複数 JSPS award の課題名（日英）が正しく取得されること
- [x] CiNii_API_KEY 未設定時に KAKEN 連携がスキップされ、従来通り動作すること
- [x] JSPS 以外の funder では KAKEN 連携が発動しないこと
- [x] 「空の入力フィールド」ボタンがエラーなく動作すること

Closes #2, Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)