### PR TITLE
feat: Crossref type → JPCOAR 資源タイプ マッピングを追加 (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ CiNii APIキー未設定でも、ISSNをもとにCiNii Research OpenSearch API�
 | 日付 | 内容 |
 |------|------|
 | 2026-02-22 | DOI必須項目バッジ表示：資源タイプに応じてJaLC/Crossref DOIの必須・条件付必須をセクションヘッダーに色付きタグ+ツールチップで動的表示（[#15](https://github.com/tzhaya/jc-import-file-maker/issues/15)） |
+| 2026-02-22 | Crossref type → JPCOAR 資源タイプ マッピングを追加：書籍・会議論文・学位論文等23タイプを正しくマッピング（[#12](https://github.com/tzhaya/jc-import-file-maker/issues/12)） |
 | 2026-02-19 | CiNii識別子UIを簡素化：特別UIを廃止し標準UIに統合、Scheme選択時のURI自動設定とCiNii Researchers検索ボタンを追加 |
 | 2026-02-19 | NCID自動取得：ISSNをもとにCiNii Research OpenSearch APIからNCIDを取得し収録物識別子に追加（[#3](https://github.com/tzhaya/jc-import-file-maker/issues/3)） |
 | 2026-02-18 | KAKEN連携：JSPS助成時にCiNii Research APIから科研費課題名・URLを自動取得（[#2](https://github.com/tzhaya/jc-import-file-maker/issues/2), [#7](https://github.com/tzhaya/jc-import-file-maker/issues/7)） |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -207,7 +207,9 @@ make_jc_importer.html
 -   **資源タイプの設定**
     -   資源タイプ（"key": "item_30002_resource_type13"）は以下のように設定します。
         -   資源タイプ："key": "item_30002_resource_type13.resourcetype"
-            -   Crossref APIで取得したmessage.type の value の値と、"key": "item_30002_resource_type13.resourcetype" の titleMap に定義されたいずれかの value と一致する場合にその値。ハイフンは空白に置き換えてかまわない。一致しない場合は空値
+            -   Crossref APIで取得したmessage.type の値を以下の優先順位でJPCOAR 資源タイプに変換する。一致しない場合は空値。
+                1. ハイフンをスペースに変換した値が titleMap に一致する場合、その値を使用（例: `journal-article` → `journal article`）
+                2. 上記で一致しない場合、`CROSSREF_TYPE_MAP`（`docs/crossref_type_mapping.md` 参照）でルックアップして対応するJPCOAR資源タイプを使用（例: `edited-book` → `book`）
         -   資源タイプ識別子："key": "item_30002_resource_type13.resourceuri"
             -   資源タイプ語彙別表で一致するURLの値。一致しない場合は空値
 

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-02-22（DOI必須項目バッジ表示）
+最終更新: 2026-02-22（Crossref type → JPCOAR 資源タイプ マッピング追加）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -8,7 +8,57 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 実装計画: `Implementation_phase1.md`
 対象ファイル: `make_jc_importer.html`（新規作成）
-現在のファイル規模: **約2739行**（STEP 1〜6 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ）
+現在のファイル規模: **約2769行**（STEP 1〜6 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング）
+
+---
+
+## 2026-02-22: Crossref type → JPCOAR 資源タイプ マッピング追加（#12）
+
+### 問題
+
+Crossref API から書籍等を取り込んだ際、資源タイプが正しく識別されない問題があった。従来のコードは Crossref の `type` フィールドのハイフンをスペースに変換するだけで、30タイプのうち7タイプしか `TITLE_MAPS.resourcetype` に一致しなかった（`edited-book` → `edited book` → 一致なし → 空）。
+
+### 実装内容
+
+**`CROSSREF_TYPE_MAP` 定数を追加**（`RESOURCE_TYPE_MAP` の直後、約L510付近）
+
+Crossref type（ハイフン付き）を直接キーとし、対応するJPCOAR資源タイプを値とするマッピングテーブル（23エントリ）を追加。マッピング根拠は `docs/crossref_type_mapping.md` に記載。
+
+**`mapToItemType()` 内の資源タイプ解決ロジックを更新**
+
+```javascript
+// 変更前
+const crType       = (crJson.type || '').replace(/-/g, ' ');
+const resourcetype = TITLE_MAPS.resourcetype.includes(crType) ? crType : '';
+
+// 変更後
+const crTypeRaw    = crJson.type || '';
+const crTypeLabel  = crTypeRaw.replace(/-/g, ' ');
+const resourcetype = TITLE_MAPS.resourcetype.includes(crTypeLabel)
+  ? crTypeLabel
+  : (CROSSREF_TYPE_MAP[crTypeRaw] || '');
+```
+
+フォールバック順序:
+1. ハイフン→スペース変換で TITLE_MAPS に一致 → そのまま使用（既存の7タイプ）
+2. `CROSSREF_TYPE_MAP` でルックアップ → 対応するJPCOAR資源タイプを使用（23タイプ）
+3. どちらも一致しない → 空文字（未知のタイプ）
+
+### マッピング概要
+
+| 変換先 | 対象 Crossref type |
+|---|---|
+| `book` | edited-book, monograph, reference-book, book-set, book-series |
+| `book part` | book-chapter, book-section, book-track, reference-entry |
+| `conference paper` | proceedings-article |
+| `conference proceedings` | proceedings, proceedings-series |
+| `thesis` | dissertation |
+| `article` | posted-content, peer-review |
+| `report` | report-series |
+| `report part` | report-component |
+| `journal` | journal-volume, journal-issue |
+| `dataset` | database |
+| `other` | standard, component, grant |
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -500,6 +500,33 @@ const RESOURCE_TYPE_MAP = {
   'other':                    'http://purl.org/coar/resource_type/c_1843',
 };
 
+// ===== Crossref type → JPCOAR 資源タイプ マッピング =====
+const CROSSREF_TYPE_MAP = {
+  'edited-book':         'book',
+  'monograph':           'book',
+  'reference-book':      'book',
+  'book-set':            'book',
+  'book-series':         'book',
+  'book-chapter':        'book part',
+  'book-section':        'book part',
+  'book-track':          'book part',
+  'reference-entry':     'book part',
+  'proceedings-article': 'conference paper',
+  'proceedings':         'conference proceedings',
+  'proceedings-series':  'conference proceedings',
+  'dissertation':        'thesis',
+  'posted-content':      'article',
+  'peer-review':         'article',
+  'report-series':       'report',
+  'report-component':    'report part',
+  'journal-volume':      'journal',
+  'journal-issue':       'journal',
+  'database':            'dataset',
+  'standard':            'other',
+  'component':           'other',
+  'grant':               'other',
+};
+
 // ===== アクセス権マッピング =====
 const ACCESS_RIGHTS_MAP = {
   'embargoed access':       'http://purl.org/coar/access_right/c_f1cf',
@@ -1240,8 +1267,11 @@ async function mapToItemType(crJson, oaJson, rorMap) {
   }];
 
   // ===== 資源タイプ =====
-  const crType        = (crJson.type || '').replace(/-/g, ' ');
-  const resourcetype  = TITLE_MAPS.resourcetype.includes(crType) ? crType : '';
+  const crTypeRaw     = crJson.type || '';
+  const crTypeLabel   = crTypeRaw.replace(/-/g, ' ');
+  const resourcetype  = TITLE_MAPS.resourcetype.includes(crTypeLabel)
+    ? crTypeLabel
+    : (CROSSREF_TYPE_MAP[crTypeRaw] || '');
   const resourceuri   = resourcetype ? (RESOURCE_TYPE_MAP[resourcetype] || '') : '';
 
   // ===== 出版タイプ =====


### PR DESCRIPTION
## Summary

- `CROSSREF_TYPE_MAP` 定数を追加（23エントリ）
- `mapToItemType()` の資源タイプ解決を2段階フォールバックに更新
  1. ハイフン→スペース変換で `TITLE_MAPS.resourcetype` に一致 → そのまま使用（既存の7タイプ）
  2. `CROSSREF_TYPE_MAP` でルックアップ → 対応するJPCOAR資源タイプを使用（23タイプ）

## Test plan

- [x] DOI `10.64096/0002000949`（Crossref type: `edited-book`）を入力し、資源タイプが `book` になることを確認
- [x] 既存の `journal-article` などが引き続き正常にマッピングされることを確認

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)