### PR TITLE
feat: Crossref ISBN・relation フィールドを関連情報に取り込む (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ CiNii APIキー未設定でも、ISSNをもとにCiNii Research OpenSearch API�
 - 空フィールドのみの表示
 - KAKEN連携：JSPS助成の科研費課題名（日英）・課題ページURL自動取得（CiNii Research Projects API）
 - NCID自動取得：ISSNからCiNii Research OpenSearch APIでNCIDを取得し収録物識別子に追加（CiNii書誌ページへの参照リンク付き）
+- Crossref ISBN・relation フィールドの関連情報への取り込み：book系でISBNをisIdenticalTo/ISBNとして追加、全資源タイプでCrossref relationフィールドのエントリを関連情報に追加
 
 ### Phase 2
 
@@ -107,6 +108,7 @@ CiNii APIキー未設定でも、ISSNをもとにCiNii Research OpenSearch API�
 
 | 日付 | 内容 |
 |------|------|
+| 2026-02-22 | Crossref ISBN・relation フィールドを関連情報に取り込み：book系でISBNをisIdenticalTo/ISBNとして追加、全資源タイプでCrossref relationフィールドに対応（[#20](https://github.com/tzhaya/jc-import-file-maker/issues/20)） |
 | 2026-02-22 | DOI必須項目バッジ表示：資源タイプに応じてJaLC/Crossref DOIの必須・条件付必須をセクションヘッダーに色付きタグ+ツールチップで動的表示（[#15](https://github.com/tzhaya/jc-import-file-maker/issues/15)） |
 | 2026-02-22 | Crossref type → JPCOAR 資源タイプ マッピングを追加：書籍・会議論文・学位論文等23タイプを正しくマッピング（[#12](https://github.com/tzhaya/jc-import-file-maker/issues/12)） |
 | 2026-02-19 | CiNii識別子UIを簡素化：特別UIを廃止し標準UIに統合、Scheme選択時のURI自動設定とCiNii Researchers検索ボタンを追加 |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -192,7 +192,31 @@ make_jc_importer.html
             -   関連識別子："key": "item_30002_relation18[].subitem_relation_type_id.subitem_relation_type_id_text"
                 -   `key`に対する `value` の値
                 -   例：https://pubmed.ncbi.nlm.nih.gov/40653270
+        -   Crossref APIの `isbn-type` / `ISBN` フィールドに含まれるISBNを関連情報に追加する（book 系資源タイプ固有）。`isbn-type` が存在する場合は優先し、なければ `ISBN` 配列にフォールバック。
+            -   関連タイプ："key": "item_30002_relation18[].subitem_relation_type"
+                -   "value": "isIdenticalTo"
+            -   識別子タイプ："key": "item_30002_relation18[].subitem_relation_type_id.subitem_relation_type_select"
+                -   "value": "ISBN"
+            -   関連識別子："key": "item_30002_relation18[].subitem_relation_type_id.subitem_relation_type_id_text"
+                -   ISBN 値
+        -   Crossref APIの `relation` フィールドに含まれる関連情報を関連情報に追加する（全資源タイプ共通）。`CROSSREF_RELATION_TYPE_MAP` および `CROSSREF_RELATION_ID_TYPE_MAP` を使用してマッピング。マッピング対象外のrelation type / id-type はスキップする。
+            -   関連タイプ："key": "item_30002_relation18[].subitem_relation_type"
+                -   `CROSSREF_RELATION_TYPE_MAP` でマッピングした JPCOAR relation type 値
+            -   識別子タイプ："key": "item_30002_relation18[].subitem_relation_type_id.subitem_relation_type_select"
+                -   `CROSSREF_RELATION_ID_TYPE_MAP` でマッピングした JPCOAR identifierType 値
+            -   関連識別子："key": "item_30002_relation18[].subitem_relation_type_id.subitem_relation_type_id_text"
+                -   Crossref `relation[*][*].id` の値
 
+**Crossref `relation` フィールドの例**
+```json
+{
+  "relation": {
+    "has-preprint": [
+      { "id-type": "doi", "id": "10.1101/2025.01.01.000001", "asserted-by": "object" }
+    ]
+  }
+}
+```
 
 **OpenAlex のJSONPATH `ids` の例**
 ```

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-02-22（Crossref type → JPCOAR 資源タイプ マッピング追加）
+最終更新: 2026-02-22（Crossref ISBN・relation フィールドの関連情報取り込み追加）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -9,6 +9,40 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 実装計画: `Implementation_phase1.md`
 対象ファイル: `make_jc_importer.html`（新規作成）
 現在のファイル規模: **約2769行**（STEP 1〜6 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング）
+
+---
+
+## 2026-02-22: Crossref ISBN・relation フィールドの関連情報取り込み追加（#20）
+
+### 問題
+
+issue #12 で Crossref type マッピングを追加した際、book 型データの検証を行ったところ、以下の情報が関連情報（`item_30002_relation18`）に取り込まれていないことを確認した。
+
+1. **`ISBN` フィールド**（book 系資源タイプ固有）: Crossref が返す ISBN が関連情報に登録されていない
+2. **`relation` フィールド**（全資源タイプ共通）: Crossref が返す関連識別子が全く処理されていない
+
+### 実装内容
+
+**定数 2 つを追加**（`CROSSREF_TYPE_MAP` 末尾直後）
+
+- `CROSSREF_RELATION_TYPE_MAP`: Crossref relation type（ハイフン区切り）→ JPCOAR relation type（17エントリ）
+- `CROSSREF_RELATION_ID_TYPE_MAP`: Crossref `id-type` → JPCOAR identifierType（6エントリ）
+
+値は `TITLE_MAPS.subitem_relation_type` / `TITLE_MAPS.subitem_relation_type_select` に完全一致させた（`arXiv` 等の大文字小文字に注意）。
+
+**`item_30002_relation18` IIFE に処理を追加**（既存の DOI / OpenAlex ids 処理の後）
+
+```
+3) Crossref ISBN エントリ（book 系）
+   isbn-type 優先 → なければ ISBN 配列にフォールバック（issn-type / ISSN と同パターン）
+   → isIdenticalTo / ISBN として追加
+
+4) Crossref relation エントリ（全資源タイプ）
+   CROSSREF_RELATION_TYPE_MAP / CROSSREF_RELATION_ID_TYPE_MAP でマッピング
+   対象外の relation type / id-type はスキップ
+```
+
+UI 側（`renderRelationField`）は変更不要（ISBN や各 relation type は既に TITLE_MAPS に定義済み）。
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -527,6 +527,37 @@ const CROSSREF_TYPE_MAP = {
   'grant':               'other',
 };
 
+// ===== Crossref relation type → JPCOAR relation type マッピング =====
+const CROSSREF_RELATION_TYPE_MAP = {
+  'is-version-of':      'isVersionOf',
+  'has-version':        'hasVersion',
+  'is-preprint-of':     'isVersionOf',
+  'has-preprint':       'hasVersion',
+  'is-part-of':         'isPartOf',
+  'has-part':           'hasPart',
+  'is-referenced-by':   'isReferencedBy',
+  'references':         'references',
+  'is-format-of':       'isFormatOf',
+  'has-format':         'hasFormat',
+  'is-identical-to':    'isIdenticalTo',
+  'is-supplement-to':   'isSupplementTo',
+  'is-supplemented-by': 'isSupplementedBy',
+  'replaces':           'replaces',
+  'is-replaced-by':     'isReplacedBy',
+  'is-cited-by':        'isCitedBy',
+  'cites':              'Cites',
+};
+
+// ===== Crossref relation id-type → JPCOAR identifierType マッピング =====
+const CROSSREF_RELATION_ID_TYPE_MAP = {
+  'doi':   'DOI',
+  'isbn':  'ISBN',
+  'issn':  'ISSN',
+  'uri':   'URI',
+  'arxiv': 'arXiv',
+  'pmid':  'PMID',
+};
+
 // ===== アクセス権マッピング =====
 const ACCESS_RIGHTS_MAP = {
   'embargoed access':       'http://purl.org/coar/access_right/c_f1cf',
@@ -1422,6 +1453,50 @@ async function mapToItemType(crJson, oaJson, rorMap) {
             subitem_relation_type_select: upperKey,
           },
           subitem_relation_name: [],
+        });
+      });
+      // 3) Crossref ISBN エントリ（book 系）
+      const isbnEntries = crJson['isbn-type'] || [];
+      if (isbnEntries.length) {
+        isbnEntries.forEach(i => {
+          relations.push({
+            subitem_relation_type: 'isIdenticalTo',
+            subitem_relation_type_id: {
+              subitem_relation_type_id_text: i.value,
+              subitem_relation_type_select: 'ISBN',
+            },
+            subitem_relation_name: [],
+          });
+        });
+      } else {
+        (crJson.ISBN || []).forEach(isbn => {
+          relations.push({
+            subitem_relation_type: 'isIdenticalTo',
+            subitem_relation_type_id: {
+              subitem_relation_type_id_text: isbn,
+              subitem_relation_type_select: 'ISBN',
+            },
+            subitem_relation_name: [],
+          });
+        });
+      }
+      // 4) Crossref relation エントリ（全資源タイプ）
+      Object.entries(crJson.relation || {}).forEach(([crRelType, items]) => {
+        const jpcoarRelType = CROSSREF_RELATION_TYPE_MAP[crRelType];
+        if (!jpcoarRelType) return;
+        (items || []).forEach(item => {
+          const jpcoarIdType = CROSSREF_RELATION_ID_TYPE_MAP[(item['id-type'] || '').toLowerCase()];
+          if (!jpcoarIdType) return;
+          const id = item.id || '';
+          if (!id) return;
+          relations.push({
+            subitem_relation_type: jpcoarRelType,
+            subitem_relation_type_id: {
+              subitem_relation_type_id_text: id,
+              subitem_relation_type_select: jpcoarIdType,
+            },
+            subitem_relation_name: [],
+          });
         });
       });
       return relations;


### PR DESCRIPTION
## 概要

issue #20 の対応。book 型データの検証で判明した以下 2 点の未実装を修正。

## 変更内容

### 新規定数
- `CROSSREF_RELATION_TYPE_MAP`: Crossref relation type（ハイフン区切り）→ JPCOAR relation type（17エントリ）
- `CROSSREF_RELATION_ID_TYPE_MAP`: Crossref `id-type` → JPCOAR identifierType（6エントリ）
- 値は `TITLE_MAPS.subitem_relation_type` / `TITLE_MAPS.subitem_relation_type_select` に完全一致

### `item_30002_relation18` への追加
- **ISBN エントリ（book 系）**: `isbn-type` 優先・`ISBN` 配列フォールバック（`issn-type`/`ISSN` と同パターン）→ `isIdenticalTo` / `ISBN`
- **Crossref relation エントリ（全資源タイプ）**: 各関連をマッピングテーブルで変換。対象外 relation type / id-type はスキップ

UI 側（`renderRelationField`）は変更なし。

## テスト方法

1. book 型 DOI（例: `10.64096/0002000949`）→ 関連情報に ISBN エントリが表示されること
2. `relation` フィールドを持つ DOI → 関連情報に対応エントリが追加されること
3. 通常の journal-article DOI → 既存の DOI / OpenAlex ids エントリが維持されること

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)