### PR TITLE
feat: 識別子から機関名を逆引きして確認・上書きする機能を追加する (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ APIキーを設定するとレート制限が緩和されます。
 
 | 日付 | 内容 |
 |------|------|
+| 2026-02-24 | 識別子からの機関名逆引き：所属機関識別子（ROR）・助成機関識別子（ROR / Crossref Funder）から「名称を確認」ボタンでAPI逆引きし、名称不一致時は「上書き」ボタンで置換可能（[#17](https://github.com/tzhaya/jc-import-file-maker/issues/17)） |
 | 2026-02-23 | JGN連携：award が `JP` で始まる場合にCrossref JGN API（prefix `10.52926`）を照会しJST助成金の課題名（日英）・課題DOI URIを自動取得。JGN未登録時はKAKEN連携にフォールバック（[#14](https://github.com/tzhaya/jc-import-file-maker/issues/14)） |
 | 2026-02-22 | Crossref ISBN・relation フィールドを関連情報に取り込み：book系でISBNをisIdenticalTo/ISBNとして追加、全資源タイプでCrossref relationフィールドに対応（[#20](https://github.com/tzhaya/jc-import-file-maker/issues/20)） |
 | 2026-02-22 | DOI必須項目バッジ表示：資源タイプに応じてJaLC/Crossref DOIの必須・条件付必須をセクションヘッダーに色付きタグ+ツールチップで動的表示（[#15](https://github.com/tzhaya/jc-import-file-maker/issues/15)） |

--- a/docs/Implementation_issue17.md
+++ b/docs/Implementation_issue17.md
@@ -1,0 +1,318 @@
+# Issue #17 実装計画: 識別子からの機関名逆引き
+
+## Context
+
+助成情報・所属機関の識別子（ROR, Crossref Funder ID）から機関名をAPIで逆引きし、
+入力済み名称との差異を警告・上書きできる機能を追加する。
+
+- 対象識別子: **ROR**（所属機関 + 助成機関）、**Crossref Funder**（助成機関）
+- 対象外: ISNI, GRID, Ringgold（APIなし）、ORCID（後日実装）
+
+---
+
+## 修正対象ファイル
+
+- `make_jc_importer.html` のみ（単一ファイル構成）
+
+---
+
+## Step 1: CSS 追加（~L354 直前）
+
+`.lookup-result` クラスを `<style>` セクション末尾に追加:
+
+```css
+/* ===== 識別子逆引き結果エリア ===== */
+.lookup-result {
+  margin: 2px 16px 4px;
+  font-size: 0.82em;
+  min-height: 1.2em;
+}
+.lookup-result.ok   { color: #2e7d32; }
+.lookup-result.warn { color: #e65100; }
+.lookup-result.err  { color: #c62828; }
+```
+
+---
+
+## Step 2: API 関数追加（~L979 直後、`fetchAllRorData` の前）
+
+### `fetchRorNamesAll(rorUri)`
+
+ROR v2 API で `ror_display` + `label` タイプの全名称を取得。
+
+```javascript
+async function fetchRorNamesAll(rorUri) {
+  const rorId = rorUri.replace(/^https?:\/\/ror\.org\//i, '').replace(/\/$/, '');
+  const resp = await fetch(`https://api.ror.org/v2/organizations/${encodeURIComponent(rorId)}`);
+  if (!resp.ok) throw new Error(`ROR APIエラー: ${resp.status}`);
+  const data = await resp.json();
+  return (data.names || [])
+    .filter(n => Array.isArray(n.types) && (n.types.includes('ror_display') || n.types.includes('label')))
+    .map(n => ({ name: n.value, lang: n.lang || '' }));
+}
+```
+
+### `fetchCrossrefFunderDetails(funderUri)`
+
+Crossref Funders API で主名称を取得。
+`funderUri` は `https://doi.org/10.13039/...` 形式で保存されている。
+
+```javascript
+async function fetchCrossrefFunderDetails(funderUri) {
+  const doi = funderUri.replace(/^https?:\/\/doi\.org\//i, '');
+  const resp = await fetch(`https://api.crossref.org/funders/${encodeURIComponent(doi)}`);
+  if (!resp.ok) throw new Error(`Crossref Funders APIエラー: ${resp.status}`);
+  const data = await resp.json();
+  const name = data.message?.name || '';
+  // alt-names は言語タグなしのため上書き対象外（表示のみ）
+  const altNames = (data.message?.['alt-names'] || []).join(', ');
+  return name
+    ? [{ name, lang: 'en', _altNames: altNames }]
+    : [];
+}
+```
+
+---
+
+## Step 3: 共通ヘルパー関数 `attachLookupUi()` 追加（~`renderOnePerson` 直前）
+
+- ボタンは呼び出し元が生成し識別子フィールド行にインライン配置（既存の CiNii 検索ボタンと同パターン）
+- 結果エリアのみ `attachLookupUi` が生成して `resultContainer` に追加する
+- Crossref Funder の `_altNames` は結果テキストに参考表示するが上書き対象外
+
+```javascript
+/**
+ * 識別子逆引きUI（結果エリアのみ生成・ボタンイベントを設定）
+ * @param {object} opts
+ *   btn           - 呼び出し元が生成した「名称を確認」ボタン要素（フィールド行にインライン配置済み）
+ *   resultContainer - 結果エリアを appendChild する DOM 要素
+ *   fetchNames    - async () => [{ name, lang, _altNames? }] を返す関数
+ *   getVisible    - () => boolean: ボタン表示可否
+ *   getTargetCont - () => DOM 要素（名称 entry-group が入るコンテナ）
+ *   nameFld       - fieldKey 名（例: 'affiliationName'）
+ *   langFld       - fieldKey 名（例: 'affiliationNameLang'）
+ *   nameLabel     - 名称フィールドのラベル（例: '所属機関名'）
+ *   langLabel     - 言語フィールドのラベル（例: '言語'）
+ * @returns { updateVisibility: fn }
+ */
+function attachLookupUi({ btn, resultContainer, fetchNames, getVisible, getTargetCont,
+                          nameFld, langFld, nameLabel, langLabel }) {
+  const resultEl = document.createElement('div');
+  resultEl.className = 'lookup-result';
+  resultContainer.appendChild(resultEl);
+
+  const updateVisibility = () => {
+    btn.style.display = getVisible() ? '' : 'none';
+    if (!getVisible()) resultEl.textContent = '';
+  };
+  updateVisibility();
+
+  btn.onclick = async (e) => {
+    e.preventDefault();
+    btn.disabled = true;
+    resultEl.className = 'lookup-result';
+    resultEl.textContent = '取得中...';
+    try {
+      const names = await fetchNames();
+      if (!names.length) {
+        resultEl.textContent = '名称が取得できませんでした。';
+        return;
+      }
+
+      const targetCont = getTargetCont();
+      const currentNames = [...targetCont.querySelectorAll(`[data-field-key="${nameFld}"] input`)]
+        .map(el => el.value.trim()).filter(Boolean);
+      const fetchedNames = names.map(n => n.name);
+      const allMatch = fetchedNames.length === currentNames.length
+        && fetchedNames.every(fn => currentNames.includes(fn));
+
+      resultEl.innerHTML = '';
+      const altInfo = names[0]?._altNames ? `（別名: ${names[0]._altNames}）` : '';
+      const namesStr = names.map(n => `${n.name}${n.lang ? ' (' + n.lang + ')' : ''}`).join(', ');
+
+      if (allMatch) {
+        resultEl.className = 'lookup-result ok';
+        resultEl.textContent = `✓ 一致確認: ${namesStr}${altInfo}`;
+      } else {
+        resultEl.className = 'lookup-result warn';
+        const warnSpan = document.createElement('span');
+        warnSpan.textContent = `⚠ 取得: ${namesStr}${altInfo} `;
+        resultEl.appendChild(warnSpan);
+
+        const overwriteBtn = document.createElement('button');
+        overwriteBtn.textContent = '上書き';
+        overwriteBtn.className = 'btn-add';
+        overwriteBtn.onclick = () => {
+          [...targetCont.querySelectorAll(':scope > .entry-group')].forEach(g => g.remove());
+          names.forEach(({ name: nm, lang }) => {
+            const { grp, delBtn } = createEntryGroup();
+            grp.appendChild(createFieldRow(nameLabel, nm, 'text', null, { fieldKey: nameFld }));
+            grp.appendChild(createFieldRow(langLabel, lang || 'en', 'select', 'language', { fieldKey: langFld }));
+            grp.appendChild(delBtn);
+            targetCont.appendChild(grp);
+          });
+          resultEl.className = 'lookup-result ok';
+          resultEl.textContent = `✓ 上書きしました: ${namesStr}`;
+        };
+        resultEl.appendChild(overwriteBtn);
+      }
+    } catch (err) {
+      resultEl.className = 'lookup-result err';
+      resultEl.textContent = `エラー: ${err.message}`;
+    } finally {
+      btn.disabled = false;
+    }
+  };
+
+  return { updateVisibility };
+}
+```
+
+---
+
+## Step 4: `renderOneAffiliation()` 修正（~L2282-2301）
+
+所属機関識別子セクションで、各エントリ（既存・新規追加とも）に逆引きUIを追加。
+
+**フィールド追加順序の制約:**
+- `attachLookupUi` 内で `updateVisibility()` を初期化時に呼ぶため、Scheme select が DOM に存在してから呼び出す必要がある
+- `let` による遅延バインディングパターンを使用する
+
+### 既存エントリ（forEach ループ内）
+
+ボタンはインライン（識別子フィールド行の末尾に追加）。CiNii 検索ボタンと同パターン。
+
+```javascript
+(aff[affIdKey] || []).forEach((aid, aidx) => {
+  const { item: aidItem, content: aidContent } = createNestedItem(`所属機関識別子[${aidx}]`, 4);
+
+  // (1) 識別子フィールド行を生成し、逆引きボタンをインライン追加
+  const idRow = createFieldRow('識別子', aid[affIdField] || '', 'text', null, { fieldKey: affIdField });
+  const lookupBtn = document.createElement('button');
+  lookupBtn.textContent = '名称を確認';
+  lookupBtn.className = 'btn-add';
+  lookupBtn.style.display = 'none';   // 初期非表示、updateVisibility で更新
+  idRow.appendChild(lookupBtn);       // フィールド行にインライン
+  aidContent.appendChild(idRow);
+
+  // (2) Scheme・URI フィールド行
+  let updateAffLookup = () => {};  // 遅延バインディング
+  aidContent.appendChild(createFieldRow('Scheme', aid[affIdSchemeField] || '', 'select',
+    'affiliationNameIdentifierScheme', {
+      fieldKey: affIdSchemeField,
+      onChange: () => updateAffLookup(),
+    }));
+  aidContent.appendChild(createFieldRow('URI', aid[affIdUriField] || '', 'text', null, { fieldKey: affIdUriField }));
+
+  // (3) Scheme select が DOM にある状態で attachLookupUi を呼ぶ
+  const { updateVisibility } = attachLookupUi({
+    btn: lookupBtn,
+    resultContainer: aidContent,
+    fetchNames: () => {
+      const uriInput = aidContent.querySelector(`[data-field-key="${affIdUriField}"] input`);
+      return fetchRorNamesAll(uriInput?.value || '');
+    },
+    getVisible: () => {
+      const schemeEl = aidContent.querySelector(`[data-field-key="${affIdSchemeField}"] select`);
+      return schemeEl?.value === 'ROR';
+    },
+    getTargetCont: () => anCont,
+    nameFld: affNameField, langFld: affNameLangField,
+    nameLabel: '所属機関名', langLabel: '言語',
+  });
+  updateAffLookup = updateVisibility;  // バインド完了
+
+  aiCont.appendChild(aidItem);
+});
+```
+
+### 新規追加（onAdd コールバック内）
+
+forEach ループと同じパターンを使用。`anCont` はクロージャで参照可能。
+
+---
+
+## Step 5: `renderOneFunder()` 修正（~L2441-2444）
+
+識別子行 + 識別子タイプ行の後に逆引きUIを追加。タイプ変更時に表示を切り替える。
+
+Step 4 と同じく「ボタンをインライン配置 → Scheme/Type select を DOM 追加 → `attachLookupUi` 呼び出し」の順。
+
+```javascript
+// 助成機関識別子（fieldset）
+const fId = funder.subitem_funder_identifiers || {};
+
+// (1) 識別子フィールド行にボタンをインライン追加
+const funderIdRow = createFieldRow('助成機関識別子', fId.subitem_funder_identifier || '', 'text', null,
+  { fieldKey: 'subitem_funder_identifier' });
+const funderLookupBtn = document.createElement('button');
+funderLookupBtn.textContent = '名称を確認';
+funderLookupBtn.className = 'btn-add';
+funderLookupBtn.style.display = 'none';
+funderIdRow.appendChild(funderLookupBtn);
+fundContent.appendChild(funderIdRow);
+
+// (2) タイプ行（変更時に updateFunderLookup 呼び出し）
+let updateFunderLookup = () => {};
+fundContent.appendChild(createFieldRow('識別子タイプ', fId.subitem_funder_identifier_type || '', 'select',
+  'subitem_funder_identifier_type', {
+    fieldKey: 'subitem_funder_identifier_type',
+    onChange: () => updateFunderLookup(),
+  }));
+
+// (3) タイプ select が DOM にある状態で attachLookupUi
+const { updateVisibility: updateFV } = attachLookupUi({
+  btn: funderLookupBtn,
+  resultContainer: fundContent,
+  fetchNames: () => {
+    const idInput = fundContent.querySelector('[data-field-key="subitem_funder_identifier"] input');
+    const typeEl  = fundContent.querySelector('[data-field-key="subitem_funder_identifier_type"] select');
+    const idVal   = idInput?.value || '';
+    const typeVal = typeEl?.value  || '';
+    if (typeVal === 'Crossref Funder') return fetchCrossrefFunderDetails(idVal);
+    if (typeVal === 'ROR')             return fetchRorNamesAll(idVal);
+    return Promise.resolve([]);
+  },
+  getVisible: () => {
+    const typeEl = fundContent.querySelector('[data-field-key="subitem_funder_identifier_type"] select');
+    return typeEl?.value === 'Crossref Funder' || typeEl?.value === 'ROR';
+  },
+  getTargetCont: () => fnCont,
+  nameFld: 'subitem_funder_name', langFld: 'subitem_funder_name_language',
+  nameLabel: '助成機関名', langLabel: '言語',
+});
+updateFunderLookup = updateFV;
+```
+
+---
+
+## 行番号インパクト
+
+| 修正箇所 | 追加行数目安 |
+|---|---|
+| CSS 追加（~L354） | +7行 |
+| `fetchRorNamesAll()` 追加（~L981） | +8行 |
+| `fetchCrossrefFunderDetails()` 追加（~L990） | +10行 |
+| `attachLookupUi()` 追加（~L1960） | +55行 |
+| `renderOneAffiliation()` 修正（~L2290） | +30行 |
+| `renderOneFunder()` 修正（~L2455） | +25行 |
+| **合計** | **~+135行** |
+
+---
+
+## 検証方法
+
+1. テスト用 DOI `10.1016/j.advnut.2025.100480` でデータ取得
+2. 所属機関セクション → 所属機関識別子 → Scheme を「ROR」に変更 → 「名称を確認」ボタンが表示される
+3. ROR URI が入っている状態でボタンをクリック → API 結果と現在の名称を比較・表示
+4. 助成情報セクション → 識別子タイプを「Crossref Funder」に変更 → 「名称を確認」ボタンが表示される
+5. ボタンをクリック → API 取得名称と比較、不一致時は「上書き」ボタンが出る
+6. 「上書き」で名称が更新されることを確認
+7. 識別子タイプを「ISNI」や「Other」に変更 → ボタンが非表示になることを確認
+
+---
+
+## ブランチ・PR
+
+- ブランチ: `feature/identifier-name-lookup`
+- PR前更新: README.md、make_jc_importer.html (version-info)、docs/requirements.md、docs/worklog.md、MEMORY.md

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -407,6 +407,15 @@ ItemType.json には複数レベルのネスト構造を持つフィールドが
 - CiNii API がエラーの場合は警告のみ出力し、Crossref データを保持（フォールバック）
 - JSPS以外の funder、award番号が空、またはJGN連携成功済みの場合はKAKEN連携をスキップ
 
+**識別子からの機関名逆引き（ROR / Crossref Funders API）**:
+- 所属機関識別子セクション: Scheme が「ROR」の場合に「名称を確認」ボタンを表示し、URI フィールドの値を使って ROR v2 API から機関名（`ror_display` + `label` タイプ）を取得
+- 助成機関識別子セクション: 識別子タイプが「ROR」または「Crossref Funder」の場合に「名称を確認」ボタンを表示し、識別子フィールドの値を使って対応 API から機関名を取得
+  - ROR: `https://api.ror.org/v2/organizations/{rorId}` → `ror_display` + `label` タイプの全名称
+  - Crossref Funder: `https://api.crossref.org/funders/{doi}` → `name`（`alt-names` は参考表示のみ、上書き対象外）
+- 取得結果と現在入力済みの名称を比較し、一致の場合は緑色で「✓ 一致確認」、不一致の場合はオレンジ色で「⚠ 取得:」と名称を表示
+- 不一致時は「上書き」ボタンを表示し、クリックすると既存の名称エントリを取得名称で置換（言語タグ付き）
+- Scheme / 識別子タイプの変更時にボタン表示を動的更新（ROR/Crossref Funder 以外では非表示）
+
 **NCID自動取得（CiNii Research Books API）**:
 - Crossref APIから取得したISSN（PISSN/EISSN）をもとに、CiNii Research OpenSearch API（books）を呼び出してNCID（NACSIS-CAT書誌ID）を自動取得する
 - CiNii APIキーは任意（未設定でもAPI呼び出し可能、設定時はレート制限緩和）

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-02-23（JGN連携追加 / JST助成金の課題名・URI自動取得）
+最終更新: 2026-02-24（識別子逆引き機能追加 / ROR・Crossref Funder からの機関名確認・上書き）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -9,6 +9,48 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 実装計画: `Implementation_phase1.md`
 対象ファイル: `make_jc_importer.html`（新規作成）
 現在のファイル規模: **約2867行**（STEP 1〜6 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング + ISBN/relation取り込み + JGN連携）
+
+---
+
+## 2026-02-24: 識別子からの機関名逆引き（#17）
+
+### 問題
+
+所属機関識別子（ROR URI）や助成機関識別子（Crossref Funder DOI / ROR URI）を入力しても、対応する機関名と照合する手段がなく、誤入力を検出できなかった。
+
+### 実装内容
+
+**CSS 追加** (`<style>` 末尾)
+
+- `.lookup-result` クラス: 結果エリア用（ok: 緑、warn: オレンジ、err: 赤）
+
+**API 関数追加** (`fetchRorDetails` 直後)
+
+- `fetchRorNamesAll(rorUri)`: ROR v2 API で `ror_display` + `label` タイプの全名称を取得
+- `fetchCrossrefFunderDetails(funderUri)`: Crossref Funders API で主名称を取得（`alt-names` は参考表示のみ）
+
+**`attachLookupUi()` ヘルパー追加** (`renderOnePerson` 直前)
+
+- ボタン（呼び出し元生成）とイベント処理・結果エリアを一体管理するユーティリティ関数
+- 遅延バインディングパターン: Scheme/Type select DOM 追加後に `attachLookupUi` を呼ぶことで `updateVisibility` を初期化
+- 比較ロジック: 取得名称と現入力値を集合比較し、完全一致で緑、不一致でオレンジ + 上書きボタン表示
+- 上書き処理: 既存の `entry-group` を削除し、API 取得名称（言語タグ付き）で再生成
+
+**`renderOneAffiliation()` 修正**
+
+- 所属機関識別子セクション（新規追加・既存エントリの両方）に逆引き UI を追加
+- Scheme 変更時のコールバックで `updateAffLookup()` を呼び出し、ROR 選択時のみボタン表示
+
+**`renderOneFunder()` 修正**
+
+- 助成機関識別子の識別子フィールド行に「名称を確認」ボタンをインライン追加
+- 識別子タイプ変更時のコールバックで `updateFunderLookup()` を呼び出し
+- タイプが ROR → `fetchRorNamesAll`、Crossref Funder → `fetchCrossrefFunderDetails` に分岐
+- `getTargetCont: () => fnCont` で助成機関名コンテナを参照し、上書き時に置換
+
+### 行数変化
+
+追加行数: +約145行（現在のファイル規模: 約3010行）
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -352,6 +352,15 @@
   .doi-badge.jalc-conditional { background: #e3f2fd; color: #1565c0; border: 1px dashed #90caf9; }
   .doi-badge.crossref-required    { background: #fce4ec; color: #c62828; border: 1px solid #ef9a9a; }
   .doi-badge.crossref-conditional { background: #fce4ec; color: #c62828; border: 1px dashed #ef9a9a; }
+  /* ===== 識別子逆引き結果エリア ===== */
+  .lookup-result {
+    margin: 2px 16px 4px;
+    font-size: 0.82em;
+    min-height: 1.2em;
+  }
+  .lookup-result.ok   { color: #2e7d32; }
+  .lookup-result.warn { color: #e65100; }
+  .lookup-result.err  { color: #c62828; }
 </style>
 </head>
 <body>
@@ -363,7 +372,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-02-23 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-02-24 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
   </div>
   <table style="border-collapse:collapse; width:100%;">
@@ -374,6 +383,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-24</td>
+        <td style="padding:2px 0;">識別子逆引き：所属機関識別子（ROR）・助成機関識別子（ROR / Crossref Funder）から「名称を確認」ボタンでAPI逆引き、名称不一致時は「上書き」で置換可能</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-23</td>
         <td style="padding:2px 0;">JGN連携：JP始まりawardにCrossref JGN API照会、JST助成金の課題名（日英）・課題DOI URIを自動取得。JGN未登録時はKAKEN連携にフォールバック</td>
@@ -976,6 +989,31 @@ async function fetchRorDetails(rorUri) {
     : '';
 
   return { isni, rorDisplayName, rorId };
+}
+
+// ===== 3.3b ROR 逆引き: ror_display + label タイプの全名称を取得 =====
+async function fetchRorNamesAll(rorUri) {
+  const rorId = rorUri.replace(/^https?:\/\/ror\.org\//i, '').replace(/\/$/, '');
+  const resp = await fetch(`https://api.ror.org/v2/organizations/${encodeURIComponent(rorId)}`);
+  if (!resp.ok) throw new Error(`ROR APIエラー: ${resp.status}`);
+  const data = await resp.json();
+  return (data.names || [])
+    .filter(n => Array.isArray(n.types) && (n.types.includes('ror_display') || n.types.includes('label')))
+    .map(n => ({ name: n.value, lang: n.lang || '' }));
+}
+
+// ===== 3.3c Crossref Funders 逆引き: 主名称を取得 =====
+async function fetchCrossrefFunderDetails(funderUri) {
+  const doi = funderUri.replace(/^https?:\/\/doi\.org\//i, '');
+  const resp = await fetch(`https://api.crossref.org/funders/${encodeURIComponent(doi)}`);
+  if (!resp.ok) throw new Error(`Crossref Funders APIエラー: ${resp.status}`);
+  const data = await resp.json();
+  const name = data.message?.name || '';
+  // alt-names は言語タグなしのため上書き対象外（表示のみ）
+  const altNames = (data.message?.['alt-names'] || []).join(', ');
+  return name
+    ? [{ name, lang: 'en', _altNames: altNames }]
+    : [];
 }
 
 // ===== 3.4 全著者の ROR データを並列取得 =====
@@ -2068,6 +2106,92 @@ function renderObjectField(def, obj) {
 
 // ===== 5.4 専用レンダラー =====
 
+// ----- 識別子逆引きUI（結果エリアのみ生成・ボタンイベントを設定）-----
+/**
+ * @param {object} opts
+ *   btn           - 呼び出し元が生成した「名称を確認」ボタン要素（フィールド行にインライン配置済み）
+ *   resultContainer - 結果エリアを appendChild する DOM 要素
+ *   fetchNames    - async () => [{ name, lang, _altNames? }] を返す関数
+ *   getVisible    - () => boolean: ボタン表示可否
+ *   getTargetCont - () => DOM 要素（名称 entry-group が入るコンテナ）
+ *   nameFld       - fieldKey 名（例: 'affiliationName'）
+ *   langFld       - fieldKey 名（例: 'affiliationNameLang'）
+ *   nameLabel     - 名称フィールドのラベル（例: '所属機関名'）
+ *   langLabel     - 言語フィールドのラベル（例: '言語'）
+ * @returns { updateVisibility: fn }
+ */
+function attachLookupUi({ btn, resultContainer, fetchNames, getVisible, getTargetCont,
+                          nameFld, langFld, nameLabel, langLabel }) {
+  const resultEl = document.createElement('div');
+  resultEl.className = 'lookup-result';
+  resultContainer.appendChild(resultEl);
+
+  const updateVisibility = () => {
+    btn.style.display = getVisible() ? '' : 'none';
+    if (!getVisible()) resultEl.textContent = '';
+  };
+  updateVisibility();
+
+  btn.onclick = async (e) => {
+    e.preventDefault();
+    btn.disabled = true;
+    resultEl.className = 'lookup-result';
+    resultEl.textContent = '取得中...';
+    try {
+      const names = await fetchNames();
+      if (!names.length) {
+        resultEl.textContent = '名称が取得できませんでした。';
+        return;
+      }
+
+      const targetCont = getTargetCont();
+      const currentNames = [...targetCont.querySelectorAll(`[data-field-key="${nameFld}"] input`)]
+        .map(el => el.value.trim()).filter(Boolean);
+      const fetchedNames = names.map(n => n.name);
+      const allMatch = fetchedNames.length === currentNames.length
+        && fetchedNames.every(fn => currentNames.includes(fn));
+
+      resultEl.innerHTML = '';
+      const altInfo = names[0]?._altNames ? `（別名: ${names[0]._altNames}）` : '';
+      const namesStr = names.map(n => `${n.name}${n.lang ? ' (' + n.lang + ')' : ''}`).join(', ');
+
+      if (allMatch) {
+        resultEl.className = 'lookup-result ok';
+        resultEl.textContent = `✓ 一致確認: ${namesStr}${altInfo}`;
+      } else {
+        resultEl.className = 'lookup-result warn';
+        const warnSpan = document.createElement('span');
+        warnSpan.textContent = `⚠ 取得: ${namesStr}${altInfo} `;
+        resultEl.appendChild(warnSpan);
+
+        const overwriteBtn = document.createElement('button');
+        overwriteBtn.textContent = '上書き';
+        overwriteBtn.className = 'btn-add';
+        overwriteBtn.onclick = () => {
+          [...targetCont.querySelectorAll(':scope > .entry-group')].forEach(g => g.remove());
+          names.forEach(({ name: nm, lang }) => {
+            const { grp, delBtn } = createEntryGroup();
+            grp.appendChild(createFieldRow(nameLabel, nm, 'text', null, { fieldKey: nameFld }));
+            grp.appendChild(createFieldRow(langLabel, lang || 'en', 'select', 'language', { fieldKey: langFld }));
+            grp.appendChild(delBtn);
+            targetCont.appendChild(grp);
+          });
+          resultEl.className = 'lookup-result ok';
+          resultEl.textContent = `✓ 上書きしました: ${namesStr}`;
+        };
+        resultEl.appendChild(overwriteBtn);
+      }
+    } catch (err) {
+      resultEl.className = 'lookup-result err';
+      resultEl.textContent = `エラー: ${err.message}`;
+    } finally {
+      btn.disabled = false;
+    }
+  };
+
+  return { updateVisibility };
+}
+
 // ----- 作成者/寄与者: 1人分のDOM生成 -----
 function renderOnePerson(person, idx, keys) {
   const {
@@ -2283,16 +2407,83 @@ function renderOneAffiliation(aff, ai, keys) {
   const { wrapper: aiWrap, content: aiCont } = createNestedSectionHeader('所属機関識別子', 3, (cont) => {
     const aidx = cont.querySelectorAll(':scope > .nested-item').length;
     const { item: aidItem, content: aidContent } = createNestedItem(`所属機関識別子[${aidx}]`, 4);
-    aidContent.appendChild(createFieldRow('識別子', '', 'text', null, { fieldKey: affIdField }));
-    aidContent.appendChild(createFieldRow('Scheme', '', 'select', 'affiliationNameIdentifierScheme', { fieldKey: affIdSchemeField }));
+
+    // (1) 識別子フィールド行を生成し、逆引きボタンをインライン追加
+    const idRow = createFieldRow('識別子', '', 'text', null, { fieldKey: affIdField });
+    const lookupBtn = document.createElement('button');
+    lookupBtn.textContent = '名称を確認';
+    lookupBtn.className = 'btn-add';
+    lookupBtn.style.display = 'none';
+    idRow.appendChild(lookupBtn);
+    aidContent.appendChild(idRow);
+
+    // (2) Scheme・URI フィールド行（Scheme 変更時に updateAffLookup 呼び出し）
+    let updateAffLookup = () => {};
+    aidContent.appendChild(createFieldRow('Scheme', '', 'select', 'affiliationNameIdentifierScheme', {
+      fieldKey: affIdSchemeField,
+      onChange: () => updateAffLookup(),
+    }));
     aidContent.appendChild(createFieldRow('URI', '', 'text', null, { fieldKey: affIdUriField }));
+
+    // (3) Scheme select が DOM にある状態で attachLookupUi を呼ぶ
+    const { updateVisibility } = attachLookupUi({
+      btn: lookupBtn,
+      resultContainer: aidContent,
+      fetchNames: () => {
+        const uriInput = aidContent.querySelector(`[data-field-key="${affIdUriField}"] input`);
+        return fetchRorNamesAll(uriInput?.value || '');
+      },
+      getVisible: () => {
+        const schemeEl = aidContent.querySelector(`[data-field-key="${affIdSchemeField}"] select`);
+        return schemeEl?.value === 'ROR';
+      },
+      getTargetCont: () => anCont,
+      nameFld: affNameField, langFld: affNameLangField,
+      nameLabel: '所属機関名', langLabel: '言語',
+    });
+    updateAffLookup = updateVisibility;
+
     cont.appendChild(aidItem);
   });
   (aff[affIdKey] || []).forEach((aid, aidx) => {
     const { item: aidItem, content: aidContent } = createNestedItem(`所属機関識別子[${aidx}]`, 4);
-    aidContent.appendChild(createFieldRow('識別子', aid[affIdField] || '', 'text', null, { fieldKey: affIdField }));
-    aidContent.appendChild(createFieldRow('Scheme', aid[affIdSchemeField] || '', 'select', 'affiliationNameIdentifierScheme', { fieldKey: affIdSchemeField }));
+
+    // (1) 識別子フィールド行を生成し、逆引きボタンをインライン追加
+    const idRow = createFieldRow('識別子', aid[affIdField] || '', 'text', null, { fieldKey: affIdField });
+    const lookupBtn = document.createElement('button');
+    lookupBtn.textContent = '名称を確認';
+    lookupBtn.className = 'btn-add';
+    lookupBtn.style.display = 'none';
+    idRow.appendChild(lookupBtn);
+    aidContent.appendChild(idRow);
+
+    // (2) Scheme・URI フィールド行（Scheme 変更時に updateAffLookup 呼び出し）
+    let updateAffLookup = () => {};
+    aidContent.appendChild(createFieldRow('Scheme', aid[affIdSchemeField] || '', 'select',
+      'affiliationNameIdentifierScheme', {
+        fieldKey: affIdSchemeField,
+        onChange: () => updateAffLookup(),
+      }));
     aidContent.appendChild(createFieldRow('URI', aid[affIdUriField] || '', 'text', null, { fieldKey: affIdUriField }));
+
+    // (3) Scheme select が DOM にある状態で attachLookupUi を呼ぶ
+    const { updateVisibility } = attachLookupUi({
+      btn: lookupBtn,
+      resultContainer: aidContent,
+      fetchNames: () => {
+        const uriInput = aidContent.querySelector(`[data-field-key="${affIdUriField}"] input`);
+        return fetchRorNamesAll(uriInput?.value || '');
+      },
+      getVisible: () => {
+        const schemeEl = aidContent.querySelector(`[data-field-key="${affIdSchemeField}"] select`);
+        return schemeEl?.value === 'ROR';
+      },
+      getTargetCont: () => anCont,
+      nameFld: affNameField, langFld: affNameLangField,
+      nameLabel: '所属機関名', langLabel: '言語',
+    });
+    updateAffLookup = updateVisibility;
+
     aiCont.appendChild(aidItem);
   });
   affItemCont.appendChild(aiWrap);
@@ -2440,8 +2631,47 @@ function renderOneFunder(funder, idx, defLabel) {
 
   // 助成機関識別子（fieldset）
   const fId = funder.subitem_funder_identifiers || {};
-  fundContent.appendChild(createFieldRow('助成機関識別子', fId.subitem_funder_identifier || '', 'text', null, { fieldKey: 'subitem_funder_identifier' }));
-  fundContent.appendChild(createFieldRow('識別子タイプ', fId.subitem_funder_identifier_type || '', 'select', 'subitem_funder_identifier_type', { fieldKey: 'subitem_funder_identifier_type' }));
+
+  // (1) 識別子フィールド行にボタンをインライン追加
+  const funderIdRow = createFieldRow('助成機関識別子', fId.subitem_funder_identifier || '', 'text', null,
+    { fieldKey: 'subitem_funder_identifier' });
+  const funderLookupBtn = document.createElement('button');
+  funderLookupBtn.textContent = '名称を確認';
+  funderLookupBtn.className = 'btn-add';
+  funderLookupBtn.style.display = 'none';
+  funderIdRow.appendChild(funderLookupBtn);
+  fundContent.appendChild(funderIdRow);
+
+  // (2) タイプ行（変更時に updateFunderLookup 呼び出し）
+  let updateFunderLookup = () => {};
+  fundContent.appendChild(createFieldRow('識別子タイプ', fId.subitem_funder_identifier_type || '', 'select',
+    'subitem_funder_identifier_type', {
+      fieldKey: 'subitem_funder_identifier_type',
+      onChange: () => updateFunderLookup(),
+    }));
+
+  // (3) タイプ select が DOM にある状態で attachLookupUi
+  const { updateVisibility: updateFV } = attachLookupUi({
+    btn: funderLookupBtn,
+    resultContainer: fundContent,
+    fetchNames: () => {
+      const idInput = fundContent.querySelector('[data-field-key="subitem_funder_identifier"] input');
+      const typeEl  = fundContent.querySelector('[data-field-key="subitem_funder_identifier_type"] select');
+      const idVal   = idInput?.value || '';
+      const typeVal = typeEl?.value  || '';
+      if (typeVal === 'Crossref Funder') return fetchCrossrefFunderDetails(idVal);
+      if (typeVal === 'ROR')             return fetchRorNamesAll(idVal);
+      return Promise.resolve([]);
+    },
+    getVisible: () => {
+      const typeEl = fundContent.querySelector('[data-field-key="subitem_funder_identifier_type"] select');
+      return typeEl?.value === 'Crossref Funder' || typeEl?.value === 'ROR';
+    },
+    getTargetCont: () => fnCont,
+    nameFld: 'subitem_funder_name', langFld: 'subitem_funder_name_language',
+    nameLabel: '助成機関名', langLabel: '言語',
+  });
+  updateFunderLookup = updateFV;
 
   // 研究課題番号（fieldset）
   const aw = funder.subitem_award_numbers || {};


### PR DESCRIPTION
## Summary

- 所属機関識別子（Scheme=ROR）と助成機関識別子（タイプ=ROR または Crossref Funder）に「名称を確認」ボタンを追加
- ボタンクリックで対応 API（ROR v2 / Crossref Funders）から機関名を逆引き
- 現在の入力値と比較し、一致→緑で確認表示、不一致→オレンジで「上書き」ボタンを提供

## Changes

- `fetchRorNamesAll(rorUri)`: ROR v2 API から `ror_display` + `label` タイプの全名称を取得
- `fetchCrossrefFunderDetails(funderUri)`: Crossref Funders API から主名称を取得（`alt-names` は参考表示のみ）
- `attachLookupUi(opts)`: 共通ヘルパー。結果エリア生成・一致比較・上書き処理を担当
- `renderOneAffiliation()` 修正: 所属機関識別子の新規追加・既存エントリに逆引き UI を追加
- `renderOneFunder()` 修正: 助成機関識別子の識別子フィールド行に逆引き UI を追加
- CSS: `.lookup-result` クラス追加（ok/warn/err の色分け）

## Test plan

- [x] テスト用 DOI `10.1016/j.advnut.2025.100480` でデータ取得
- [x] 所属機関セクション → 所属機関識別子 → Scheme を「ROR」に変更 → 「名称を確認」ボタンが表示される
- [x] ROR URI が入っている状態でボタンをクリック → API 結果と現在の名称を比較・表示
- [x] 助成情報セクション → 識別子タイプを「Crossref Funder」に変更 → 「名称を確認」ボタンが表示される
- [x] ボタンをクリック → API 取得名称と比較、不一致時は「上書き」ボタンが出る
- [x] 「上書き」で名称が更新されることを確認
- [x] 識別子タイプを「ISNI」や「Other」に変更 → ボタンが非表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)