### PR TITLE
feat: JPCOAR 2.0 資源タイプ語彙対応・出版タイプリソース自動設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ APIキーを設定するとレート制限が緩和されます。
 
 | 日付 | 内容 |
 |------|------|
+| 2026-02-24 | JPCOAR スキーマ 2.0 資源タイプ語彙対応：`RESOURCE_TYPE_MAP` に v2.0 の31型（データセットサブタイプ・特許サブタイプ等）を追加し、セレクトメニューも更新（docs/resource_type_vocabulary.md も更新） |
+| 2026-02-24 | 出版タイプ選択時に出版タイプリソース URI を自動設定（COAR version type vocabulary、`VERSION_TYPE_MAP` 追加） |
 | 2026-02-24 | 識別子からの機関名逆引き：所属機関識別子（ROR）・助成機関識別子（ROR / Crossref Funder）から「名称を確認」ボタンでAPI逆引きし、名称不一致時は「上書き」ボタンで置換可能（[#17](https://github.com/tzhaya/jc-import-file-maker/issues/17)） |
 | 2026-02-23 | JGN連携：award が `JP` で始まる場合にCrossref JGN API（prefix `10.52926`）を照会しJST助成金の課題名（日英）・課題DOI URIを自動取得。JGN未登録時はKAKEN連携にフォールバック（[#14](https://github.com/tzhaya/jc-import-file-maker/issues/14)） |
 | 2026-02-22 | Crossref ISBN・relation フィールドを関連情報に取り込み：book系でISBNをisIdenticalTo/ISBNとして追加、全資源タイプでCrossref relationフィールドに対応（[#20](https://github.com/tzhaya/jc-import-file-maker/issues/20)） |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -39,6 +39,8 @@ make_jc_importer.html
 
 **資源タイプ語彙別表**
     -　`resource_type_vocabulary.md`
+    - JPCOAR スキーマ 2.0 の語彙に対応（v2.0追加型・v1.0のみ型を区分表示）
+    - 出典: v1.0 https://schema.irdb.nii.ac.jp/ja/resource_type_vocabulary / v2.0 https://schema.irdb.nii.ac.jp/ja/2.0/resource_type_vocabulary
 
 **JPCOARスキーマ 項目別説明リンク一覧**
     - `JPCOARschme_guide.md`

--- a/docs/resource_type_vocabulary.md
+++ b/docs/resource_type_vocabulary.md
@@ -1,54 +1,157 @@
 # Resource Type Vocabulary（資源タイプ語彙別表）
 
-出典: https://schema.irdb.nii.ac.jp/ja/resource_type_vocabulary
+出典（v1.0）: https://schema.irdb.nii.ac.jp/ja/resource_type_vocabulary
+出典（v2.0）: https://schema.irdb.nii.ac.jp/ja/2.0/resource_type_vocabulary
 URI仕様: http://purl.org/coar/resource_type/
 
-| 英語名 | 日本語名 | 定義 | rdf:resource |
-|---|---|---|---|
-| conference paper | 会議発表論文 | 会議に提出され、参加者に発表された論文で、会議録に掲載される | http://purl.org/coar/resource_type/c_5794 |
-| data paper | データ論文 | 特定のデータセットやデータセットグループについて記述され、学術雑誌における査読論文の形式で出版されるもの | http://purl.org/coar/resource_type/c_beb9 |
-| departmental bulletin paper | 紀要論文 | 大学や研究所等が発行する紀要類に掲載された論文 | http://purl.org/coar/resource_type/c_6501 |
-| editorial | エディトリアル | 学術雑誌の編集長によって記述された、政治的、社会的、文化的、専門的な問題に関する見解を示したエッセイ | http://purl.org/coar/resource_type/c_b239 |
-| journal article | 学術雑誌論文 | 特定の主題に関して研究を実施した1人以上の著者によって執筆され、学術雑誌に掲載された論文 | http://purl.org/coar/resource_type/c_6501 |
-| newspaper | 新聞 | 折りたたまれ、ホッチキス止めされていない紙面で構成され、ニュースや記事、広告、通信を含む、印刷された出版物 | http://purl.org/coar/resource_type/c_2fe3 |
-| periodical | 逐次刊行物 | 固有のタイトルを持ち、多様なコンテンツから構成される一定の間隔で発行される逐次刊行物 | http://purl.org/coar/resource_type/c_2659 |
-| review article | レビュー論文 | 二次情報であり、他の記事について書かれた論文。オリジナルの研究に関する報告ではない | http://purl.org/coar/resource_type/c_dcae04bc |
-| software paper | ソフトウェア論文 | ツールの開発に関する論理的根拠や構築時に使用したコードの詳細情報を含むもの | http://purl.org/coar/resource_type/c_7bab |
-| article | 記事 | 上記には含まれない、学術論文以外の記事 | http://purl.org/coar/resource_type/c_6501 |
-| book | 図書 | 1巻またはセットで完結する逐次性のない出版物で、原則ISBNで識別される | http://purl.org/coar/resource_type/c_2f33 |
-| book part | 図書（部分） | 図書の章または一節で、通常は見出しまたは番号で区別される | http://purl.org/coar/resource_type/c_3248 |
-| cartographic material | 地図資料 | 地球全体または一部、あるいは天体を任意のスケールで表現したもの | http://purl.org/coar/resource_type/c_12cc |
-| map | 地図 | 地球または別の天体の地表に関連する物質や特徴を抜粋し、平面に縮小したもの | http://purl.org/coar/resource_type/c_12cd |
-| conference object | 会議発表資料 | 会議で発表された、プレゼンテーション資料、会議報告、講義資料、抄録、デモンストレーションなどの電子的な資料全般 | http://purl.org/coar/resource_type/c_c94f |
-| conference proceedings | 会議録 | 会議で発表された資料の集合であり、付属的な資料も含む会議の公式な記録 | http://purl.org/coar/resource_type/c_f744 |
-| conference poster | 会議発表ポスター | 会議に提出され、ポスター発表に用いられたポスターで、会議録に掲載される | http://purl.org/coar/resource_type/c_6670 |
-| dataset | データセット | 関連するファクトデータを集めたもの。数値形式で表現され、構造化されているものが多い | http://purl.org/coar/resource_type/c_ddb1 |
-| interview | インタビュー | レポーター、主催者、パネリスト、聴衆と著名人、著者、有名人との間の議論を、紙媒体、映画、ビデオに転写物としてまたは音声として記録したもの | http://purl.org/coar/resource_type/c_26e4 |
-| image | イメージ | 画像や映像を含む、文字以外で視覚的に表現されたもの | http://purl.org/coar/resource_type/c_c513 |
-| still image | 静止画 | 静的に記録された画像で、ダイアグラム、図面、グラフ、グラフィックデザイン、図面、地図、写真、印画を含む | http://purl.org/coar/resource_type/c_ecc8 |
-| moving image | 動画 | コンピュータプログラムによって動的に生成されたり、事前に記録された静止画像の連続表示によって表現された動的な映像 | http://purl.org/coar/resource_type/c_8a7e |
-| video | 録画資料 | テレビまたは電子機器を介して再生されるように設計されている、何らかの動きと音楽を伴う視覚的な画像の記録資料 | http://purl.org/coar/resource_type/c_12ce |
-| lecture | 講演 | 就任記念講演などの学術的なイベントにおいて用いられた講演資料およびプレゼンテーション資料 | http://purl.org/coar/resource_type/c_8544 |
-| patent | 特許 | 特許または特許出願書類 | http://purl.org/coar/resource_type/c_15cd |
-| internal report | 内部報告書 | 組織内部での使用を目的として収集された調査結果の記録 | http://purl.org/coar/resource_type/c_18ww |
-| report | 報告書 | 研究成果、進行中の研究内容、その他の技術的知見を個別に公表したもの | http://purl.org/coar/resource_type/c_93fc |
-| research report | 研究報告書 | 特定のトピックに関する詳細な研究や、ある研究プロジェクトでの結果が記述された報告書 | http://purl.org/coar/resource_type/c_18ws |
-| technical report | テクニカルレポート | 技術的・科学的研究および研究課題のプロセス、進捗状況や結果を記述した文書 | http://purl.org/coar/resource_type/c_18gh |
-| policy report | ポリシーレポート | 主要なポリシーの策定やイベントの詳細が記載された報告書 | http://purl.org/coar/resource_type/c_186u |
-| report part | 報告書（部分） | 報告書の一部 | http://purl.org/coar/resource_type/c_ba1f |
-| working paper | ワーキングペーパー | 編集上の改善提案や情報提供を受けるため、少人数のグループで私的に閲覧される未発表の論文 | http://purl.org/coar/resource_type/c_8042 |
-| data management plan | データ管理計画 | 研究プロジェクトの期間中および終了後におけるデータの収集・管理方法および場所の概要を示した正式な文書 | http://purl.org/coar/resource_type/c_ab20 |
-| sound | 音声・音楽 | 音楽再生ファイルフォーマット、オーディオコンパクトディスク、録音されたスピーチや音楽などの聴覚的な資料 | http://purl.org/coar/resource_type/c_18cc |
-| thesis | 学位論文 | 研究と知見を表現することにより、学位または専門資格の候補者であることを示すために提出された文書 | http://purl.org/coar/resource_type/c_46ec |
-| bachelor thesis | 学士論文 | 学士号の取得につながる学部・学科教育の一環として実施された、研究プロジェクトを報告する論文 | http://purl.org/coar/resource_type/c_7a1f |
-| master thesis | 修士論文 | 修士号の取得につながる大学院教育の一環として実施された、研究プロジェクトを報告する論文 | http://purl.org/coar/resource_type/c_bdcc |
-| doctoral thesis | 博士論文 | 博士課程期間中に行われた研究を報告する論文 | http://purl.org/coar/resource_type/c_db06 |
-| interactive resource | インタラクティブリソース | ユーザの理解、実行、経験を促すために、ユーザーとの相互作用を必要とするリソース | http://purl.org/coar/resource_type/c_e9a0 |
-| learning object | 教材 | 授業等で用いられる資料 | http://purl.org/coar/resource_type/c_e059 |
-| manuscript | 手稿 | 全体が手書きされた様々な種類の著作物（テキスト、題辞、楽譜、地図など） | http://purl.org/coar/resource_type/c_0040 |
-| musical notation | 楽譜 | 伝統的または現代の演奏記号によって記述され、聴覚的に認識される音楽を視覚的に表現したもの | http://purl.org/coar/resource_type/c_18cw |
-| research proposal | 研究計画書 | 助成金の申請に用いる文書。データ管理計画書も含む | http://purl.org/coar/resource_type/c_baaf |
-| software | ソフトウェア | ソースコード（テキスト）またはコンパイルされた形式のコンピュータプログラム | http://purl.org/coar/resource_type/c_5ce6 |
-| technical documentation | 技術文書 | 開発中または使用中の工業製品について、取扱いや機能および構造を記述した文書全般 | http://purl.org/coar/resource_type/c_71bd |
-| workflow | ワークフロー | 特定のジョブを実行する際に自動または確実に実行される一連の手順を記録したもの | http://purl.org/coar/resource_type/c_393c |
-| other | その他 | 上記で明示的に取り上げられていない、その他全ての概念をカバーするもの | http://purl.org/coar/resource_type/c_1843 |
+## 凡例
+
+| 区分 | 意味 |
+|---|---|
+| v1.0 | JPCOAR スキーマ 1.0 から存在 |
+| **v2.0追加** | JPCOAR スキーマ 2.0 で追加 |
+| v1.0のみ | JPCOAR スキーマ 2.0 には存在しない（廃止の可能性あり） |
+
+## Articles（論文・記事）
+
+| 英語名 | 日本語名 | 定義 | rdf:resource | 区分 |
+|---|---|---|---|---|
+| conference paper | 会議発表論文 | 会議に提出され、参加者に発表された論文で、会議録に掲載される | http://purl.org/coar/resource_type/c_5794 | v1.0 |
+| data paper | データ論文 | 特定のデータセットやデータセットグループについて記述され、学術雑誌における査読論文の形式で出版されるもの | http://purl.org/coar/resource_type/c_beb9 | v1.0 |
+| departmental bulletin paper | 紀要論文 | 大学や研究所等が発行する紀要類に掲載された論文 | http://purl.org/coar/resource_type/c_6501 | v1.0 |
+| editorial | エディトリアル | 学術雑誌の編集長によって記述された、政治的、社会的、文化的、専門的な問題に関する見解を示したエッセイ | http://purl.org/coar/resource_type/c_b239 | v1.0 |
+| **journal** | **学術雑誌** | **独自の研究や最新の動向を広めることを目的とする逐次刊行物** | **http://purl.org/coar/resource_type/c_0640** | **v2.0追加** |
+| journal article | 学術雑誌論文 | 特定の主題に関して研究を実施した1人以上の著者によって執筆され、学術雑誌に掲載された論文 | http://purl.org/coar/resource_type/c_6501 | v1.0 |
+| newspaper | 新聞 | 折りたたまれ、ホッチキス止めされていない紙面で構成され、ニュースや記事、広告、通信を含む、印刷された出版物 | http://purl.org/coar/resource_type/c_2fe3 | v1.0 |
+| **other periodical** | **その他の逐次刊行物** | **既存の語彙に該当しないテキスト資料** | **http://purl.org/coar/resource_type/QX5C-AR31** | **v2.0追加** |
+| review article | レビュー論文 | 二次情報であり、他の記事について書かれた論文。オリジナルの研究に関する報告ではない | http://purl.org/coar/resource_type/c_dcae04bc | v1.0 |
+| software paper | ソフトウェア論文 | ツールの開発に関する論理的根拠や構築時に使用したコードの詳細情報を含むもの | http://purl.org/coar/resource_type/c_7bab | v1.0 |
+| article | 記事 | 上記には含まれない、学術論文以外の記事 | http://purl.org/coar/resource_type/c_6501 | v1.0 |
+| periodical | 逐次刊行物 | 固有のタイトルを持ち、多様なコンテンツから構成される一定の間隔で発行される逐次刊行物 | http://purl.org/coar/resource_type/c_2659 | v1.0のみ |
+
+## Books（図書）
+
+| 英語名 | 日本語名 | 定義 | rdf:resource | 区分 |
+|---|---|---|---|---|
+| book | 図書 | 1巻またはセットで完結する逐次性のない出版物で、原則ISBNで識別される | http://purl.org/coar/resource_type/c_2f33 | v1.0 |
+| book part | 図書（部分） | 図書の章または一節で、通常は見出しまたは番号で区別される | http://purl.org/coar/resource_type/c_3248 | v1.0 |
+
+## Cartographic Material（地図資料）
+
+| 英語名 | 日本語名 | 定義 | rdf:resource | 区分 |
+|---|---|---|---|---|
+| cartographic material | 地図資料 | 地球全体または一部、あるいは天体を任意のスケールで表現したもの | http://purl.org/coar/resource_type/c_12cc | v1.0 |
+| map | 地図 | 地球または別の天体の地表に関連する物質や特徴を抜粋し、平面に縮小したもの | http://purl.org/coar/resource_type/c_12cd | v1.0 |
+
+## Conference Output（会議資料）
+
+v2.0 では "conference object"（会議発表資料）が "conference output"（会議資料）に改称されました（URI は同一: `c_c94f`）。
+
+| 英語名 | 日本語名 | 定義 | rdf:resource | 区分 |
+|---|---|---|---|---|
+| conference output | 会議資料 | 会議で発表された、プレゼンテーション資料、会議報告、講義資料、抄録、デモンストレーションなどの電子的な資料全般 | http://purl.org/coar/resource_type/c_c94f | v1.0 |
+| **conference presentation** | **会議発表スライド** | **スライド資料で、参加者にむけてアイデアや研究成果を発表したもの** | **http://purl.org/coar/resource_type/R60J-J5BD** | **v2.0追加** |
+| conference proceedings | 会議録 | 会議で発表された資料の集合であり、付属的な資料も含む会議の公式な記録 | http://purl.org/coar/resource_type/c_f744 | v1.0 |
+| conference poster | 会議発表ポスター | 会議に提出され、ポスター発表に用いられたポスターで、会議録に掲載される | http://purl.org/coar/resource_type/c_6670 | v1.0 |
+
+## Dataset（データセット）
+
+v2.0 では dataset のサブタイプが多数追加されました。
+
+| 英語名 | 日本語名 | 定義 | rdf:resource | 区分 |
+|---|---|---|---|---|
+| **aggregated data** | **集計データ** | **広範な分類に関する統計で、個人を判別不可能なもの** | **http://purl.org/coar/resource_type/ACF7-8YT9** | **v2.0追加** |
+| **clinical trial data** | **臨床試験データ** | **被験者への介入研究から得られたデータ** | **http://purl.org/coar/resource_type/c_cb28** | **v2.0追加** |
+| **compiled data** | **編集データ** | **複数の情報源から収集・整理された統合データ** | **http://purl.org/coar/resource_type/FXF3-D3G7** | **v2.0追加** |
+| dataset | データセット | 関連するファクトデータを集めたもの。数値形式で表現され、構造化されているものが多い | http://purl.org/coar/resource_type/c_ddb1 | v1.0 |
+| **encoded data** | **符号化データ** | **定性的データを定量的データに変換したもの** | **http://purl.org/coar/resource_type/AM6W-6QAW** | **v2.0追加** |
+| **experimental data** | **実験データ** | **実験的研究方法で得られたデータ** | **http://purl.org/coar/resource_type/63NG-B465** | **v2.0追加** |
+| **genomic data** | **ゲノムデータ** | **DNA由来のデータ、生物情報学で使用されるもの** | **http://purl.org/coar/resource_type/A8F1-NPV9** | **v2.0追加** |
+| **geospatial data** | **地理空間データ** | **地表上の特定地点に関連付いた様々なデータ** | **http://purl.org/coar/resource_type/2H0M-X761** | **v2.0追加** |
+| **laboratory notebook** | **実験ノート** | **仮説、実験結果の初期段階解析を文書化した研究ノート** | **http://purl.org/coar/resource_type/H41Y-FW7B** | **v2.0追加** |
+| **measurement and test data** | **測定・評価データ** | **事前に定められた基準で評価して得られたデータ** | **http://purl.org/coar/resource_type/DD58-GFSX** | **v2.0追加** |
+| **observational data** | **観測データ** | **独立変数を操作せず観察から得られたデータ** | **http://purl.org/coar/resource_type/FF4C-28RK** | **v2.0追加** |
+| **recorded data** | **記録データ** | **機械的または電子的手段により記録されたデータ** | **http://purl.org/coar/resource_type/CQMR-7K63** | **v2.0追加** |
+| **simulation data** | **シミュレーションデータ** | **コンピュータプログラムで現実世界をモデル化して得たデータ** | **http://purl.org/coar/resource_type/W2XT-7017** | **v2.0追加** |
+| **survey data** | **調査データ** | **調査によって得られたデータ** | **http://purl.org/coar/resource_type/NHD0-W6SY** | **v2.0追加** |
+
+## Image（イメージ）
+
+| 英語名 | 日本語名 | 定義 | rdf:resource | 区分 |
+|---|---|---|---|---|
+| image | イメージ | 画像や映像を含む、文字以外で視覚的に表現されたもの | http://purl.org/coar/resource_type/c_c513 | v1.0 |
+| still image | 静止画 | 静的に記録された画像で、ダイアグラム、図面、グラフ、グラフィックデザイン、図面、地図、写真、印画を含む | http://purl.org/coar/resource_type/c_ecc8 | v1.0 |
+| moving image | 動画 | コンピュータプログラムによって動的に生成されたり、事前に記録された静止画像の連続表示によって表現された動的な映像 | http://purl.org/coar/resource_type/c_8a7e | v1.0 |
+| video | 録画資料 | テレビまたは電子機器を介して再生されるように設計されている、何らかの動きと音楽を伴う視覚的な画像の記録資料 | http://purl.org/coar/resource_type/c_12ce | v1.0 |
+
+## Lecture（講演）
+
+| 英語名 | 日本語名 | 定義 | rdf:resource | 区分 |
+|---|---|---|---|---|
+| lecture | 講演 | 就任記念講演などの学術的なイベントにおいて用いられた講演資料およびプレゼンテーション資料 | http://purl.org/coar/resource_type/c_8544 | v1.0 |
+
+## Patent（特許）
+
+v2.0 では特許のサブタイプが追加されました。
+
+| 英語名 | 日本語名 | 定義 | rdf:resource | 区分 |
+|---|---|---|---|---|
+| **design patent** | **意匠特許** | **工業製品の装飾的なデザイン発明に与えられる特許** | **http://purl.org/coar/resource_type/C53B-JCY5** | **v2.0追加** |
+| patent | 特許 | 特許または特許出願書類 | http://purl.org/coar/resource_type/c_15cd | v1.0 |
+| **PCT application** | **PCT出願** | **PCT国際出願制度で申請された特許および出願願書** | **http://purl.org/coar/resource_type/SB3Y-W4EH** | **v2.0追加** |
+| **plant patent** | **植物特許** | **新品種の植物を発明・発見した人に与えられる特許** | **http://purl.org/coar/resource_type/Z907-YMBB** | **v2.0追加** |
+| **plant variety protection** | **育成者権** | **新しい植物品種の育成者に与えられる知的財産権** | **http://purl.org/coar/resource_type/GPQ7-G5VE** | **v2.0追加** |
+| **software patent** | **ソフトウェア特許** | **実質的な特許基準を満たすソフトウェアを保護対象とする特許** | **http://purl.org/coar/resource_type/MW8G-3CR8** | **v2.0追加** |
+| **trademark** | **商標** | **企業の商品またはサービスを区別する標識に関連するデータ** | **http://purl.org/coar/resource_type/H6QP-SC1X** | **v2.0追加** |
+| **utility model** | **実用新案** | **保護期間が短く特許性の要件が緩い特許またはその願書** | **http://purl.org/coar/resource_type/9DKX-KSAF** | **v2.0追加** |
+
+## Report（報告書）
+
+| 英語名 | 日本語名 | 定義 | rdf:resource | 区分 |
+|---|---|---|---|---|
+| internal report | 内部報告書 | 組織内部での使用を目的として収集された調査結果の記録 | http://purl.org/coar/resource_type/c_18ww | v1.0のみ |
+| report | 報告書 | 研究成果、進行中の研究内容、その他の技術的知見を個別に公表したもの | http://purl.org/coar/resource_type/c_93fc | v1.0 |
+| research report | 研究報告書 | 特定のトピックに関する詳細な研究や、ある研究プロジェクトでの結果が記述された報告書 | http://purl.org/coar/resource_type/c_18ws | v1.0 |
+| technical report | テクニカルレポート | 技術的・科学的研究および研究課題のプロセス、進捗状況や結果を記述した文書 | http://purl.org/coar/resource_type/c_18gh | v1.0 |
+| policy report | ポリシーレポート | 主要なポリシーの策定やイベントの詳細が記載された報告書 | http://purl.org/coar/resource_type/c_186u | v1.0 |
+| report part | 報告書（部分） | 報告書の一部 | http://purl.org/coar/resource_type/c_ba1f | v1.0のみ |
+| working paper | ワーキングペーパー | 編集上の改善提案や情報提供を受けるため、少人数のグループで私的に閲覧される未発表の論文 | http://purl.org/coar/resource_type/c_8042 | v1.0 |
+| data management plan | データ管理計画 | 研究プロジェクトの期間中および終了後におけるデータの収集・管理方法および場所の概要を示した正式な文書 | http://purl.org/coar/resource_type/c_ab20 | v1.0 |
+
+## Sound（音声・音楽）
+
+| 英語名 | 日本語名 | 定義 | rdf:resource | 区分 |
+|---|---|---|---|---|
+| sound | 音声・音楽 | 音楽再生ファイルフォーマット、オーディオコンパクトディスク、録音されたスピーチや音楽などの聴覚的な資料 | http://purl.org/coar/resource_type/c_18cc | v1.0 |
+
+## Thesis（学位論文）
+
+| 英語名 | 日本語名 | 定義 | rdf:resource | 区分 |
+|---|---|---|---|---|
+| thesis | 学位論文 | 研究と知見を表現することにより、学位または専門資格の候補者であることを示すために提出された文書 | http://purl.org/coar/resource_type/c_46ec | v1.0 |
+| bachelor thesis | 学士論文 | 学士号の取得につながる学部・学科教育の一環として実施された、研究プロジェクトを報告する論文 | http://purl.org/coar/resource_type/c_7a1f | v1.0 |
+| master thesis | 修士論文 | 修士号の取得につながる大学院教育の一環として実施された、研究プロジェクトを報告する論文 | http://purl.org/coar/resource_type/c_bdcc | v1.0 |
+| doctoral thesis | 博士論文 | 博士課程期間中に行われた研究を報告する論文 | http://purl.org/coar/resource_type/c_db06 | v1.0 |
+
+## Other（その他）
+
+| 英語名 | 日本語名 | 定義 | rdf:resource | 区分 |
+|---|---|---|---|---|
+| **commentary** | **論評** | **既存の出版物に注目を集めるために執筆される深い分析** | **http://purl.org/coar/resource_type/D97F-VB57** | **v2.0追加** |
+| **design** | **デザイン** | **建造物や工業製品などの作り方、仕組みを示す設計書や図面一式** | **http://purl.org/coar/resource_type/542X-3S04** | **v2.0追加** |
+| **industrial design** | **工業デザイン** | **工業製品の装飾的・美的側面、線や色の構成** | **http://purl.org/coar/resource_type/JBNF-DYAD** | **v2.0追加** |
+| interactive resource | インタラクティブリソース | ユーザの理解、実行、経験を促すために、ユーザーとの相互作用を必要とするリソース | http://purl.org/coar/resource_type/c_e9a0 | v1.0 |
+| **layout design** | **レイアウト設計** | **集積回路の素子と配線の三次元配列** | **http://purl.org/coar/resource_type/BW7T-YM2G** | **v2.0追加** |
+| learning object | 教材 | 授業等で用いられる資料 | http://purl.org/coar/resource_type/c_e059 | v1.0 |
+| manuscript | 手稿 | 全体が手書きされた様々な種類の著作物（テキスト、題辞、楽譜、地図など） | http://purl.org/coar/resource_type/c_0040 | v1.0 |
+| musical notation | 楽譜 | 伝統的または現代の演奏記号によって記述され、聴覚的に認識される音楽を視覚的に表現したもの | http://purl.org/coar/resource_type/c_18cw | v1.0 |
+| **peer review** | **査読** | **同分野の他の研究者による科学的・学術的評価** | **http://purl.org/coar/resource_type/H9BQ-739P** | **v2.0追加** |
+| research proposal | 研究計画書 | 助成金の申請に用いる文書。データ管理計画書も含む | http://purl.org/coar/resource_type/c_baaf | v1.0 |
+| **research protocol** | **研究プロトコル** | **プロジェクト概要、目的、方法論を示した詳細な計画書** | **http://purl.org/coar/resource_type/YZ1N-ZFT9** | **v2.0追加** |
+| software | ソフトウェア | ソースコード（テキスト）またはコンパイルされた形式のコンピュータプログラム | http://purl.org/coar/resource_type/c_5ce6 | v1.0 |
+| **source code** | **ソースコード** | **人間が読める形式のプログラミング言語で書かれたコード** | **http://purl.org/coar/resource_type/QH80-2R4E** | **v2.0追加** |
+| technical documentation | 技術文書 | 開発中または使用中の工業製品について、取扱いや機能および構造を記述した文書全般 | http://purl.org/coar/resource_type/c_71bd | v1.0 |
+| **transcription** | **文字起こし** | **公判、スピーチ、インタビューから書き起こした記録** | **http://purl.org/coar/resource_type/6NC7-GK9S** | **v2.0追加** |
+| workflow | ワークフロー | 特定のジョブを実行する際に自動または確実に実行される一連の手順を記録したもの | http://purl.org/coar/resource_type/c_393c | v1.0 |
+| other | その他 | 上記で明示的に取り上げられていない、その他全ての概念をカバーするもの | http://purl.org/coar/resource_type/c_1843 | v1.0 |
+| interview | インタビュー | レポーター、主催者、パネリスト、聴衆と著名人、著者、有名人との間の議論を、紙媒体、映画、ビデオに転写物としてまたは音声として記録したもの | http://purl.org/coar/resource_type/c_26e4 | v1.0のみ |

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-02-24（識別子逆引き機能追加 / ROR・Crossref Funder からの機関名確認・上書き）
+最終更新: 2026-02-24（JPCOAR 2.0 資源タイプ語彙対応 / 出版タイプリソース自動設定）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -8,7 +8,53 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 実装計画: `Implementation_phase1.md`
 対象ファイル: `make_jc_importer.html`（新規作成）
-現在のファイル規模: **約2867行**（STEP 1〜6 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング + ISBN/relation取り込み + JGN連携）
+現在のファイル規模: **約2900行**（STEP 1〜6 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング + ISBN/relation取り込み + JGN連携 + 識別子逆引き + JPCOAR 2.0 語彙対応）
+
+---
+
+## 2026-02-24: JPCOAR 2.0 資源タイプ語彙対応・出版タイプリソース自動設定
+
+### 問題
+
+1. **出版タイプリソース未設定**: 出版タイプ（AO/AM/VoR 等）のセレクトを変更しても出版タイプリソース URI が自動設定されなかった。
+2. **資源タイプ 2.0 未対応**: JPCOAR スキーマ 2.0 で追加された資源タイプ（データセットサブタイプ・特許サブタイプ等）が選択できても `RESOURCE_TYPE_MAP` に対応エントリがなく、`resourceuri` が空になっていた。
+
+### 実装内容
+
+**`VERSION_TYPE_MAP` 定数追加** (`ACCESS_RIGHTS_MAP` 直前)
+
+- AO / SMUR / AM / P / VoR / CVoR / EVoR / NA の8型を COAR version type vocabulary URI にマッピング
+- 出典: http://vocabularies.coar-repositories.org/version_types/
+
+**FIELD_DEFS 修正** (`item_30002_version_type15`)
+
+- `subitem_version_type` フィールドに `link: { tgt: 'subitem_version_resource', map: VERSION_TYPE_MAP }` を追加
+- `subitem_version_resource` フィールドに `ro: true` を追加（自動入力のため readonly 化）
+- 資源タイプの `resourcetype` → `resourceuri` 自動設定と同一パターン
+
+**`RESOURCE_TYPE_MAP` 拡張**
+
+- v2.0 追加型 31 件を追加（コメントで `// v2.0追加` を明記）
+  - Articles: `journal`（c_0640）、`other periodical`（QX5C-AR31）
+  - Conference Output: `conference output`（c_c94f、旧 `conference object` の改称）、`conference presentation`（R60J-J5BD）
+  - Dataset サブタイプ 13 型: aggregated data / clinical trial data / compiled data / encoded data / experimental data / genomic data / geospatial data / laboratory notebook / measurement and test data / observational data / recorded data / simulation data / survey data
+  - Patent サブタイプ 7 型: design patent / PCT application / plant patent / plant variety protection / software patent / trademark / utility model
+  - Other 8 型: commentary / design / industrial design / layout design / peer review / research protocol / source code / transcription
+- v1.0 のみの型（periodical / interview / internal report / report part）にコメント `// v1.0のみ` を追加
+
+**`TITLE_MAPS.resourcetype` 更新**
+
+- Patent サブタイプ 7 型、Other 8 型（計 15 型）をセレクトメニューに追加
+- patent の直前に特許サブタイプをグループ化して配置
+
+**`docs/resource_type_vocabulary.md` 全面更新**
+
+- v1.0 / v2.0 の両出典 URL を明記
+- 「凡例」セクション追加（v1.0 / v2.0追加 / v1.0のみ の区分）
+- カテゴリ別構成に再編（Articles / Books / Cartographic Material / Conference Output / Dataset / Image / Lecture / Patent / Report / Sound / Thesis / Other）
+- v2.0 追加型を **太字** で明示
+- v2.0 で廃止の可能性がある型（periodical / interview / internal report / report part）を "v1.0のみ" で明示
+- `conference object` → `conference output` の改称を注記
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -385,6 +385,14 @@
     <tbody>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-24</td>
+        <td style="padding:2px 0;">JPCOAR 2.0 資源タイプ語彙対応：v2.0の31型（データセットサブタイプ・特許サブタイプ等）を RESOURCE_TYPE_MAP に追加、セレクトメニュー更新</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-24</td>
+        <td style="padding:2px 0;">出版タイプ選択時に出版タイプリソース URI を自動設定（COAR version type vocabulary）</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-24</td>
         <td style="padding:2px 0;">識別子逆引き：所属機関識別子（ROR）・助成機関識別子（ROR / Crossref Funder）から「名称を確認」ボタンでAPI逆引き、名称不一致時は「上書き」で置換可能</td>
       </tr>
       <tr>
@@ -500,51 +508,95 @@ const EXCLUDED_KEYS = new Set([
 
 // ===== 資源タイプ語彙マッピング =====
 const RESOURCE_TYPE_MAP = {
+  // ----- Articles -----
   'conference paper':         'http://purl.org/coar/resource_type/c_5794',
   'data paper':               'http://purl.org/coar/resource_type/c_beb9',
   'departmental bulletin paper': 'http://purl.org/coar/resource_type/c_6501',
   'editorial':                'http://purl.org/coar/resource_type/c_b239',
+  'journal':                  'http://purl.org/coar/resource_type/c_0640',    // v2.0追加
   'journal article':          'http://purl.org/coar/resource_type/c_6501',
   'newspaper':                'http://purl.org/coar/resource_type/c_2fe3',
-  'periodical':               'http://purl.org/coar/resource_type/c_2659',
+  'other periodical':         'http://purl.org/coar/resource_type/QX5C-AR31', // v2.0追加
+  'periodical':               'http://purl.org/coar/resource_type/c_2659',    // v1.0のみ
   'review article':           'http://purl.org/coar/resource_type/c_dcae04bc',
   'software paper':           'http://purl.org/coar/resource_type/c_7bab',
   'article':                  'http://purl.org/coar/resource_type/c_6501',
+  // ----- Books -----
   'book':                     'http://purl.org/coar/resource_type/c_2f33',
   'book part':                'http://purl.org/coar/resource_type/c_3248',
+  // ----- Cartographic Material -----
   'cartographic material':    'http://purl.org/coar/resource_type/c_12cc',
   'map':                      'http://purl.org/coar/resource_type/c_12cd',
-  'conference object':        'http://purl.org/coar/resource_type/c_c94f',
+  // ----- Conference Output -----
+  'conference output':        'http://purl.org/coar/resource_type/c_c94f',    // v2.0改称（旧: conference object）
+  'conference object':        'http://purl.org/coar/resource_type/c_c94f',    // 後方互換
+  'conference presentation':  'http://purl.org/coar/resource_type/R60J-J5BD', // v2.0追加
   'conference proceedings':   'http://purl.org/coar/resource_type/c_f744',
   'conference poster':        'http://purl.org/coar/resource_type/c_6670',
+  // ----- Dataset -----
+  'aggregated data':          'http://purl.org/coar/resource_type/ACF7-8YT9', // v2.0追加
+  'clinical trial data':      'http://purl.org/coar/resource_type/c_cb28',    // v2.0追加
+  'compiled data':            'http://purl.org/coar/resource_type/FXF3-D3G7', // v2.0追加
   'dataset':                  'http://purl.org/coar/resource_type/c_ddb1',
-  'interview':                'http://purl.org/coar/resource_type/c_26e4',
+  'encoded data':             'http://purl.org/coar/resource_type/AM6W-6QAW', // v2.0追加
+  'experimental data':        'http://purl.org/coar/resource_type/63NG-B465', // v2.0追加
+  'genomic data':             'http://purl.org/coar/resource_type/A8F1-NPV9', // v2.0追加
+  'geospatial data':          'http://purl.org/coar/resource_type/2H0M-X761', // v2.0追加
+  'laboratory notebook':      'http://purl.org/coar/resource_type/H41Y-FW7B', // v2.0追加
+  'measurement and test data':'http://purl.org/coar/resource_type/DD58-GFSX', // v2.0追加
+  'observational data':       'http://purl.org/coar/resource_type/FF4C-28RK', // v2.0追加
+  'recorded data':            'http://purl.org/coar/resource_type/CQMR-7K63', // v2.0追加
+  'simulation data':          'http://purl.org/coar/resource_type/W2XT-7017', // v2.0追加
+  'survey data':              'http://purl.org/coar/resource_type/NHD0-W6SY', // v2.0追加
+  // ----- Image -----
+  'interview':                'http://purl.org/coar/resource_type/c_26e4',    // v1.0のみ
   'image':                    'http://purl.org/coar/resource_type/c_c513',
   'still image':              'http://purl.org/coar/resource_type/c_ecc8',
   'moving image':             'http://purl.org/coar/resource_type/c_8a7e',
   'video':                    'http://purl.org/coar/resource_type/c_12ce',
+  // ----- Lecture -----
   'lecture':                  'http://purl.org/coar/resource_type/c_8544',
+  // ----- Patent -----
+  'design patent':            'http://purl.org/coar/resource_type/C53B-JCY5', // v2.0追加
   'patent':                   'http://purl.org/coar/resource_type/c_15cd',
-  'internal report':          'http://purl.org/coar/resource_type/c_18ww',
+  'PCT application':          'http://purl.org/coar/resource_type/SB3Y-W4EH', // v2.0追加
+  'plant patent':             'http://purl.org/coar/resource_type/Z907-YMBB', // v2.0追加
+  'plant variety protection': 'http://purl.org/coar/resource_type/GPQ7-G5VE', // v2.0追加
+  'software patent':          'http://purl.org/coar/resource_type/MW8G-3CR8', // v2.0追加
+  'trademark':                'http://purl.org/coar/resource_type/H6QP-SC1X', // v2.0追加
+  'utility model':            'http://purl.org/coar/resource_type/9DKX-KSAF', // v2.0追加
+  // ----- Report -----
+  'internal report':          'http://purl.org/coar/resource_type/c_18ww',    // v1.0のみ
   'report':                   'http://purl.org/coar/resource_type/c_93fc',
   'research report':          'http://purl.org/coar/resource_type/c_18ws',
   'technical report':         'http://purl.org/coar/resource_type/c_18gh',
   'policy report':            'http://purl.org/coar/resource_type/c_186u',
-  'report part':              'http://purl.org/coar/resource_type/c_ba1f',
+  'report part':              'http://purl.org/coar/resource_type/c_ba1f',    // v1.0のみ
   'working paper':            'http://purl.org/coar/resource_type/c_8042',
   'data management plan':     'http://purl.org/coar/resource_type/c_ab20',
+  // ----- Sound -----
   'sound':                    'http://purl.org/coar/resource_type/c_18cc',
+  // ----- Thesis -----
   'thesis':                   'http://purl.org/coar/resource_type/c_46ec',
   'bachelor thesis':          'http://purl.org/coar/resource_type/c_7a1f',
   'master thesis':            'http://purl.org/coar/resource_type/c_bdcc',
   'doctoral thesis':          'http://purl.org/coar/resource_type/c_db06',
+  // ----- Other -----
+  'commentary':               'http://purl.org/coar/resource_type/D97F-VB57', // v2.0追加
+  'design':                   'http://purl.org/coar/resource_type/542X-3S04', // v2.0追加
+  'industrial design':        'http://purl.org/coar/resource_type/JBNF-DYAD', // v2.0追加
   'interactive resource':     'http://purl.org/coar/resource_type/c_e9a0',
+  'layout design':            'http://purl.org/coar/resource_type/BW7T-YM2G', // v2.0追加
   'learning object':          'http://purl.org/coar/resource_type/c_e059',
   'manuscript':               'http://purl.org/coar/resource_type/c_0040',
   'musical notation':         'http://purl.org/coar/resource_type/c_18cw',
+  'peer review':              'http://purl.org/coar/resource_type/H9BQ-739P', // v2.0追加
   'research proposal':        'http://purl.org/coar/resource_type/c_baaf',
+  'research protocol':        'http://purl.org/coar/resource_type/YZ1N-ZFT9', // v2.0追加
   'software':                 'http://purl.org/coar/resource_type/c_5ce6',
+  'source code':              'http://purl.org/coar/resource_type/QH80-2R4E', // v2.0追加
   'technical documentation':  'http://purl.org/coar/resource_type/c_71bd',
+  'transcription':            'http://purl.org/coar/resource_type/6NC7-GK9S', // v2.0追加
   'workflow':                 'http://purl.org/coar/resource_type/c_393c',
   'other':                    'http://purl.org/coar/resource_type/c_1843',
 };
@@ -605,6 +657,18 @@ const CROSSREF_RELATION_ID_TYPE_MAP = {
   'uri':   'URI',
   'arxiv': 'arXiv',
   'pmid':  'PMID',
+};
+
+// ===== 出版タイプ URI マッピング =====
+const VERSION_TYPE_MAP = {
+  'AO':   'http://purl.org/coar/version/c_b1a7d7d4d402bcce',
+  'SMUR': 'http://purl.org/coar/version/c_71e4c1898caa6e32',
+  'AM':   'http://purl.org/coar/version/c_ab4af688f83e57aa',
+  'P':    'http://purl.org/coar/version/c_fa2ee174bc00049f',
+  'VoR':  'http://purl.org/coar/version/c_970fb48d4fbd8a85',
+  'CVoR': 'http://purl.org/coar/version/c_e19f295774971610',
+  'EVoR': 'http://purl.org/coar/version/c_dc82b40f9837b551',
+  'NA':   'http://purl.org/coar/version/c_be7fb7dd8ff6fe43',
 };
 
 // ===== アクセス権マッピング =====
@@ -723,11 +787,16 @@ const TITLE_MAPS = {
     'genomic data','geospatial data','laboratory notebook','measurement and test data',
     'observational data','recorded data','simulation data','survey data',
     'dataset','image','still image','moving image','video',
-    'lecture','patent','internal report','report','research report','technical report',
+    'lecture',
+    'design patent','patent','PCT application','plant patent','plant variety protection',
+    'software patent','trademark','utility model',
+    'internal report','report','research report','technical report',
     'policy report','report part','working paper','data management plan',
     'sound','thesis','bachelor thesis','master thesis','doctoral thesis',
-    'interactive resource','learning object','manuscript','musical notation',
-    'research proposal','software','technical documentation','workflow','other'
+    'commentary','design','industrial design','interactive resource','layout design',
+    'learning object','manuscript','musical notation','peer review',
+    'research proposal','research protocol','software','source code',
+    'technical documentation','transcription','workflow','other'
   ],
   // アクセス権
   subitem_access_right: ['embargoed access','metadata only access','open access','restricted access'],
@@ -1743,8 +1812,8 @@ const FIELD_DEFS = [
     sum: o => o?.subitem_version || '' },
   { key: 'item_30002_version_type15', label: '出版タイプ', type: 'object',
     fields: [
-      { k: 'subitem_version_type', l: '出版タイプ', t: 'select', o: 'subitem_version_type' },
-      { k: 'subitem_version_resource', l: '出版タイプリソース', t: 'text' },
+      { k: 'subitem_version_type', l: '出版タイプ', t: 'select', o: 'subitem_version_type', link: { tgt: 'subitem_version_resource', map: VERSION_TYPE_MAP } },
+      { k: 'subitem_version_resource', l: '出版タイプリソース', t: 'text', ro: true },
     ],
     sum: o => o?.subitem_version_type || '' },
   { key: 'item_30002_identifier16', label: '識別子', type: 'array',


### PR DESCRIPTION
## Summary

- **出版タイプリソース自動設定**: `VERSION_TYPE_MAP` を追加し、出版タイプ（AO/SMUR/AM/P/VoR/CVoR/EVoR/NA）選択時に COAR version type URI を自動設定。`subitem_version_resource` は readonly 化
- **JPCOAR 2.0 資源タイプ語彙対応**: `RESOURCE_TYPE_MAP` に v2.0 追加の31型を追加し、`TITLE_MAPS.resourcetype` に選択肢として15型を追加
- **`docs/resource_type_vocabulary.md` 全面更新**: v2.0 出典 URL・凡例・カテゴリ別構成・v2.0追加型の明示（太字）・v1.0のみ型の明示

## 変更詳細

### 出版タイプリソース自動設定
- `VERSION_TYPE_MAP` 定数を `ACCESS_RIGHTS_MAP` 直前に追加
- FIELD_DEFS `item_30002_version_type15` の `subitem_version_type` フィールドに `link: { tgt: 'subitem_version_resource', map: VERSION_TYPE_MAP }` を追加
- `subitem_version_resource` に `ro: true` を追加

### RESOURCE_TYPE_MAP 拡張（v2.0 31型）
- Articles: `journal`、`other periodical`
- Conference Output: `conference output`（旧 `conference object` の改称、URI 同一）、`conference presentation`
- Dataset サブタイプ13型: aggregated / clinical trial / compiled / encoded / experimental / genomic / geospatial / laboratory notebook / measurement and test / observational / recorded / simulation / survey data
- Patent サブタイプ7型: design patent / PCT application / plant patent / plant variety protection / software patent / trademark / utility model
- Other 8型: commentary / design / industrial design / layout design / peer review / research protocol / source code / transcription

### TITLE_MAPS 拡張（15型追加）
- Patent サブタイプ7型・Other 8型をセレクトメニューに追加

### docs/resource_type_vocabulary.md
- v1.0 / v2.0 の両出典 URL を明記
- 凡例追加（v1.0 / **v2.0追加** / v1.0のみ）
- カテゴリ別に再編（12カテゴリ）
- v2.0 廃止の可能性がある型（periodical / interview / internal report / report part）を "v1.0のみ" で明示

## Test plan

- [x] 出版タイプ（AO/AM/VoR 等）を選択すると出版タイプリソース URI が自動設定されることを確認
- [x] 資源タイプセレクトで v2.0 追加型（`journal`、`aggregated data` 等）を選択すると `resourceuri` が設定されることを確認
- [x] 既存の資源タイプ（`journal article`、`dataset` 等）が引き続き正常動作することを確認
- [x] セレクトメニューに新規追加した特許サブタイプ・その他型が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)