### PR TITLE
feat: Crossref 複数日付取り込み（accepted/submitted）

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ APIキーを設定するとレート制限が緩和されます。
 
 | 日付 | 内容 |
 |------|------|
+| 2026-02-25 | Crossref の受理日（`accepted`）・提出日（`submitted`）を日付フィールドに追加取得し、Accepted / Submitted タイプとして記録（[#24](https://github.com/tzhaya/jc-import-file-maker/issues/24)） |
 | 2026-02-24 | JPCOAR スキーマ 2.0 資源タイプ語彙対応：`RESOURCE_TYPE_MAP` に v2.0 の31型（データセットサブタイプ・特許サブタイプ等）を追加し、セレクトメニューも更新（docs/resource_type_vocabulary.md も更新） |
 | 2026-02-24 | 出版タイプ選択時に出版タイプリソース URI を自動設定（COAR version type vocabulary、`VERSION_TYPE_MAP` 追加） |
 | 2026-02-24 | 識別子からの機関名逆引き：所属機関識別子（ROR）・助成機関識別子（ROR / Crossref Funder）から「名称を確認」ボタンでAPI逆引きし、名称不一致時は「上書き」ボタンで置換可能（[#17](https://github.com/tzhaya/jc-import-file-maker/issues/17)） |

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-02-24（JPCOAR 2.0 資源タイプ語彙対応 / 出版タイプリソース自動設定）
+最終更新: 2026-02-25（Crossref 複数日付取り込み）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -9,6 +9,44 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 実装計画: `Implementation_phase1.md`
 対象ファイル: `make_jc_importer.html`（新規作成）
 現在のファイル規模: **約2900行**（STEP 1〜6 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング + ISBN/relation取り込み + JGN連携 + 識別子逆引き + JPCOAR 2.0 語彙対応）
+
+---
+
+## 2026-02-25: Crossref 複数日付取り込み（issue #24）
+
+### 問題
+
+Crossref API から取得する日付は `published-online` / `published-print` / `published` を優先順で1件取得し、`Issued` タイプとして記録するのみだった。
+Crossref には受理日（`accepted`）・提出日（`submitted`）フィールドもあり、これらが存在する場合は JPCOAR スキーマ定義（「関連する情報があれば必ず記入する」）に従って記録する必要があった。
+
+### 実装内容
+
+**`formatDateParts()` ヘルパー関数を追加**（`getPubDate()` の直前）
+
+- `date-parts` 配列を受け取り `YYYY-MM-DD` / `YYYY-MM` / `YYYY` 形式の文字列に変換する低レベルヘルパー
+- 既存の `getPubDate()` も `formatDateParts()` を利用するようリファクタリング
+
+**`mapToItemType()` に `acceptedDate` / `submittedDate` を追加**
+
+- `crJson.accepted?.['date-parts']?.[0]` → `acceptedDate`
+- `crJson.submitted?.['date-parts']?.[0]` → `submittedDate`
+
+**`item_30002_date11` を複数エントリ配列に拡張**
+
+```javascript
+item_30002_date11: [
+  pubDate       && { subitem_date_issued_datetime: pubDate,       subitem_date_issued_type: 'Issued' },
+  acceptedDate  && { subitem_date_issued_datetime: acceptedDate,  subitem_date_issued_type: 'Accepted' },
+  submittedDate && { subitem_date_issued_datetime: submittedDate, subitem_date_issued_type: 'Submitted' },
+].filter(Boolean)
+```
+
+`&&` + `.filter(Boolean)` により「フィールドが存在すれば必ず追加、存在しなければスキップ」を実現。
+
+### 対象外
+
+- `posted` → `Available`：JPCOAR スキーマで `Available` はエンブレッシュ解除日（`coar:accessRights = embargoed access` 時）の意味であり、プレプリント公開日とは意味が異なるため除外。
+- `created` / `deposited` / `indexed`：Crossref のシステム管理日でありコンテンツの日付ではないため除外。
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -372,7 +372,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-02-24 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-02-25 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
   </div>
   <table style="border-collapse:collapse; width:100%;">
@@ -383,6 +383,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-25</td>
+        <td style="padding:2px 0;">Crossref の受理日（accepted）・提出日（submitted）を日付フィールドに追加取得（Accepted / Submitted タイプ）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-24</td>
         <td style="padding:2px 0;">JPCOAR 2.0 資源タイプ語彙対応：v2.0の31型（データセットサブタイプ・特許サブタイプ等）を RESOURCE_TYPE_MAP に追加、セレクトメニュー更新</td>
@@ -1282,15 +1286,20 @@ function processAbstract(raw) {
   return text;
 }
 
+// ===== 日付パーツフォーマット =====
+function formatDateParts(parts = []) {
+  if (!parts.length) return '';
+  if (parts.length >= 3) return `${parts[0]}-${String(parts[1]).padStart(2,'0')}-${String(parts[2]).padStart(2,'0')}`;
+  if (parts.length === 2) return `${parts[0]}-${String(parts[1]).padStart(2,'0')}`;
+  return String(parts[0]);
+}
+
 // ===== 発行日取得 =====
 function getPubDate(cr) {
   const parts = cr['published-online']?.['date-parts']?.[0]
     || cr['published-print']?.['date-parts']?.[0]
     || cr.published?.['date-parts']?.[0] || [];
-  if (!parts.length) return '';
-  if (parts.length >= 3) return `${parts[0]}-${String(parts[1]).padStart(2,'0')}-${String(parts[2]).padStart(2,'0')}`;
-  if (parts.length === 2) return `${parts[0]}-${String(parts[1]).padStart(2,'0')}`;
-  return String(parts[0]);
+  return formatDateParts(parts);
 }
 
 // ===== 4.3 著者マッピング =====
@@ -1432,8 +1441,10 @@ async function buildFunders(crFunders) {
 
 // ===== 4.1 メインマッピング関数 =====
 async function mapToItemType(crJson, oaJson, rorMap) {
-  const doi        = crJson.DOI || '';
-  const pubDate    = getPubDate(crJson);
+  const doi           = crJson.DOI || '';
+  const pubDate       = getPubDate(crJson);
+  const acceptedDate  = formatDateParts(crJson.accepted?.['date-parts']?.[0] || []);
+  const submittedDate = formatDateParts(crJson.submitted?.['date-parts']?.[0] || []);
   const isOa       = oaJson.open_access?.is_oa   || false;
   const oaStatus   = oaJson.open_access?.oa_status || '';
   const isGoldOa   = isOa && (oaStatus === 'gold' || oaStatus === 'hybrid');
@@ -1571,9 +1582,11 @@ async function mapToItemType(crJson, oaJson, rorMap) {
       : [],
 
     // ----- 日付 -----
-    item_30002_date11: pubDate
-      ? [{ subitem_date_issued_datetime: pubDate, subitem_date_issued_type: 'Issued' }]
-      : [],
+    item_30002_date11: [
+      pubDate       && { subitem_date_issued_datetime: pubDate,       subitem_date_issued_type: 'Issued' },
+      acceptedDate  && { subitem_date_issued_datetime: acceptedDate,  subitem_date_issued_type: 'Accepted' },
+      submittedDate && { subitem_date_issued_datetime: submittedDate, subitem_date_issued_type: 'Submitted' },
+    ].filter(Boolean),
 
     // ----- 言語 -----
     item_30002_language12: [{ subitem_language: 'eng' }],


### PR DESCRIPTION
## 概要

Closes #24

Crossref API から受理日（`accepted`）・提出日（`submitted`）を取得し、`item_30002_date11`（日付フィールド）に Accepted / Submitted タイプとして追加。

## 変更内容

### `formatDateParts()` ヘルパー追加

`date-parts` 配列を `YYYY-MM-DD` / `YYYY-MM` / `YYYY` 形式の文字列に変換する低レベルヘルパーを切り出し。`getPubDate()` もこれを利用するようリファクタリング。

### `item_30002_date11` を複数エントリ配列に拡張

| Crossref フィールド | JPCOAR 日付タイプ |
|---|---|
| `published-online` / `published-print` / `published` | Issued（実装済み） |
| `accepted` | Accepted ✅ |
| `submitted` | Submitted ✅ |
| `posted` | Available ❌ 対象外（エンブレッシュ解除日の意味のため） |

`&&` + `.filter(Boolean)` パターンにより「フィールドが存在すれば必ず追加、なければスキップ」を実現。JPCOAR スキーマの「関連する情報があれば必ず記入する」要件を満たす。

## テスト計画

- [x] `accepted` / `submitted` フィールドを含む DOI で Accepted / Submitted が日付フィールドに表示されることを確認
- [x] これらフィールドを持たない DOI で余分なエントリが追加されないことを確認
- [x] `published` のみの DOI で Issued のみが記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)