### PR TITLE
feat: 関連情報の取得改善（DOI URL統一・タイトル自動取得）

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ APIキーを設定するとレート制限が緩和されます。
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-01 | 関連情報の取得改善：関連DOIのURL形式統一（`https://doi.org/`プレフィックス付与）、関連名称（タイトル）の自動取得（Crossref/JaLC API）、JaLC API relation_listフィールド名修正（[#42](https://github.com/tzhaya/jc-import-file-maker/issues/42)） |
 | 2026-02-27 | プレビュー機能追加：入力済みメタデータをJAIRO Cloud風コンパクトテーブルでモーダル表示。collectFromDOM()によるDOM→JSON変換基盤を実装（[#37](https://github.com/tzhaya/jc-import-file-maker/issues/37)） |
 | 2026-02-26 | JaLC API対応（準備中）：JaLC DOIからのメタデータ取得・マッピングコードを追加。CORS制約により未有効化（[#6](https://github.com/tzhaya/jc-import-file-maker/issues/6)） |
 | 2026-02-25 | GitHub 最新コミットとの比較による更新チェック機能追加、インデックスID入力欄をシステム管理フィールドに移行、更新概要を直近5件に制限（[#36](https://github.com/tzhaya/jc-import-file-maker/issues/36)） |

--- a/docs/Implementation_issue42.md
+++ b/docs/Implementation_issue42.md
@@ -1,0 +1,283 @@
+# Issue #42 実装計画: 関連情報（relation）の取得改善
+
+## Context
+
+関連情報（`item_30002_relation18`）について以下2点を改善する:
+
+1. **DOI の URL 形式統一**: Crossref `relation` から取得した DOI が素のテキスト（例: `10.1101/...`）で格納されるが、入力 DOI や OpenAlex ids は URL 形式（`https://doi.org/...`）。形式を統一する。
+2. **関連名称の自動取得**: `subitem_relation_name` が常に空配列 `[]` のまま。DOI タイプの関連エントリについて、Crossref パスでは Crossref API、JaLC パスでは JaLC API からタイトルを取得して設定する。
+
+---
+
+## 修正対象ファイル
+
+- `make_jc_importer.html` のみ（単一ファイル構成）
+
+---
+
+## Step 1: タイトル取得関数の新設（~L1142 `fetchJaLC()` 直後）
+
+### 1a. `fetchRelationTitle()` — Crossref パス用
+
+関連 DOI のタイトルと言語を Crossref API から取得する軽量関数。
+
+```javascript
+/**
+ * 関連DOIのタイトルと言語を Crossref API から取得
+ * @param {string} doi - DOI（URL形式でも素のDOIでも可）
+ * @returns {Promise<{title: string, lang: string}|null>}
+ */
+async function fetchRelationTitle(doi) {
+  const bareDoi = doi.replace(/^https?:\/\/doi\.org\//i, '');
+  try {
+    const resp = await fetch(`https://api.crossref.org/works/${encodeURIComponent(bareDoi)}`);
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    const msg = data.message || {};
+    const title = (msg.title || [])[0] || '';
+    const lang = msg.language || 'en';
+    return title ? { title, lang } : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+### 1b. `fetchRelationTitleJaLC()` — JaLC パス用
+
+関連 DOI のタイトルを JaLC API から取得。JaLC DOI は Crossref に情報がないため、JaLC API を使用する。
+JaLC の `title_list` は多言語対応（`[{ title, lang }, ...]`）なので、最初のタイトルを返す。
+
+```javascript
+/**
+ * 関連DOIのタイトルと言語を JaLC API から取得
+ * @param {string} doi - DOI（URL形式でも素のDOIでも可）
+ * @returns {Promise<{title: string, lang: string}|null>}
+ */
+async function fetchRelationTitleJaLC(doi) {
+  const bareDoi = doi.replace(/^https?:\/\/doi\.org\//i, '');
+  try {
+    const resp = await fetch(`https://api.japanlinkcenter.org/v2/dois/${encodeURIComponent(bareDoi)}`, {
+      headers: { 'Accept': 'application/json' },
+    });
+    if (!resp.ok) return null;
+    const json = await resp.json();
+    const titles = (json.data || {}).title_list || [];
+    const first = titles[0];
+    return first?.title ? { title: first.title, lang: first.lang || 'ja' } : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+**設計ポイント**:
+- 両関数ともエラー時は `null` を返し silent fail（呼び出し元で graceful degradation）
+- `fetchCrossref()` / `fetchJaLC()` を再利用しない理由: 既存関数は 404 で throw するが、関連 DOI の取得失敗は正常系
+- JaLC の `title_list` は多言語だが、最初の 1 件を採用（通常は主タイトル）
+- JaLC のデフォルト言語は `ja`（日本語 DOI が主）
+
+---
+
+## Step 2: `mapToItemType()` の relation 部分修正（L1893-1971）
+
+### 2a. IIFE 廃止・直接コード展開
+
+現在 `item_30002_relation18` は IIFE `(() => { ... })()` で構築されているが、`await` を使用するため IIFE を廃止し、`mapToItemType()` 本体に直接展開する。`mapToItemType()` 自体は既に async なのでそのまま `await` が使える。
+
+**変更前** (L1893):
+```javascript
+item_30002_relation18: (() => {
+  const VALID_RELATION_ID_TYPES = new Set([...]);
+  const relations = [];
+  // ... 構築処理 ...
+  return relations;
+})(),
+```
+
+**変更後**:
+```javascript
+item_30002_relation18: await (async () => {
+  const VALID_RELATION_ID_TYPES = new Set([...]);
+  const relations = [];
+  // ... 構築処理（Step 2b, 2c の変更含む）...
+  return relations;
+})(),
+```
+
+> オブジェクトリテラル内で `await` を使うため `async` IIFE に変更。メタデータオブジェクト全体の構造を維持。
+
+### 2b. DOI URL 形式統一（セクション4内）
+
+**変更前** (L1960-1964):
+```javascript
+relations.push({
+  subitem_relation_type: jpcoarRelType,
+  subitem_relation_type_id: {
+    subitem_relation_type_id_text: id,
+    subitem_relation_type_select: jpcoarIdType,
+  },
+  subitem_relation_name: [],
+});
+```
+
+**変更後**:
+```javascript
+const idText = jpcoarIdType === 'DOI' && !/^https?:\/\//i.test(id)
+  ? `https://doi.org/${id}` : id;
+relations.push({
+  subitem_relation_type: jpcoarRelType,
+  subitem_relation_type_id: {
+    subitem_relation_type_id_text: idText,
+    subitem_relation_type_select: jpcoarIdType,
+  },
+  subitem_relation_name: [],
+});
+```
+
+### 2c. 関連名称の自動取得（セクション4 の後、`return relations;` の前）
+
+`isIdenticalTo` 以外の DOI エントリを収集し、`Promise.all` で並列にタイトル取得する。
+
+```javascript
+// 5) DOI タイプの関連エントリにタイトルを設定（isIdenticalTo は自身の識別子なので除外）
+const doiRelEntries = [];
+relations.forEach((rel, i) => {
+  if (rel.subitem_relation_type !== 'isIdenticalTo'
+      && rel.subitem_relation_type_id.subitem_relation_type_select === 'DOI') {
+    doiRelEntries.push({ index: i, doi: rel.subitem_relation_type_id.subitem_relation_type_id_text });
+  }
+});
+const titles = await Promise.all(doiRelEntries.map(e => fetchRelationTitle(e.doi)));
+doiRelEntries.forEach((e, i) => {
+  if (titles[i]) {
+    relations[e.index].subitem_relation_name = [{
+      subitem_relation_name_text: titles[i].title,
+      subitem_relation_name_language: titles[i].lang,
+    }];
+  }
+});
+```
+
+**対象外の理由**:
+- `isIdenticalTo`: 自身の DOI・OpenAlex IDs・ISBN — 自論文の識別子なので名称取得不要
+
+---
+
+## Step 3: `mapToItemTypeJaLC()` の relation 部分修正（L2136-2157）
+
+### 3a. フィールド名修正 + DOI URL 形式統一
+
+既存コードの JaLC API フィールド名が実際のレスポンスと不一致のため修正する。
+
+JaLC API 実際のレスポンス:
+```json
+"relation_list": [
+  { "content": "https://doi.org/10.34556/...", "type": "DOI", "relation": "hasVersion" },
+  { "content": "https://example.com/...", "type": "URL", "relation": "hasVersion" }
+]
+```
+
+**変更前** (L2145-2157):
+```javascript
+(jalcJson.relation_list || []).forEach(r => {
+  const relType = r.relation_type || '';
+  const idType  = r.identifier_type || '';
+  const id      = r.related_identifier || r.url || '';
+  if (!id) return;
+  const jpcoarRelType = relType || 'isReferencedBy';
+  const jpcoarIdType  = idType || 'URI';
+  relations.push({
+    subitem_relation_type: jpcoarRelType,
+    subitem_relation_type_id: { subitem_relation_type_id_text: id, subitem_relation_type_select: jpcoarIdType },
+    subitem_relation_name: [],
+  });
+});
+```
+
+**変更後**:
+```javascript
+(jalcJson.relation_list || []).forEach(r => {
+  const relType = r.relation || '';
+  const idType  = r.type || '';
+  const id      = r.content || '';
+  if (!id) return;
+  const jpcoarRelType = relType || 'isReferencedBy';
+  const jpcoarIdType  = idType || 'URI';
+  const idText = jpcoarIdType === 'DOI' && !/^https?:\/\//i.test(id)
+    ? `https://doi.org/${id}` : id;
+  relations.push({
+    subitem_relation_type: jpcoarRelType,
+    subitem_relation_type_id: { subitem_relation_type_id_text: idText, subitem_relation_type_select: jpcoarIdType },
+    subitem_relation_name: [],
+  });
+});
+```
+
+### 3b. 関連名称の自動取得（relation_list ループの後）
+
+Step 2c と同じパターンだが、**JaLC API** を使用。`isIdenticalTo`（自身の DOI エントリ）を除外し、DOI タイプのエントリのタイトルを JaLC API から取得。
+
+JaLC の `relation_list` にはタイトル情報が含まれないため、関連 DOI の `title_list` を `fetchRelationTitleJaLC()` で別途取得する。
+
+```javascript
+// DOI タイプの関連エントリにタイトルを設定（JaLC API 使用）
+const doiRelEntries = [];
+relations.forEach((rel, i) => {
+  if (rel.subitem_relation_type !== 'isIdenticalTo'
+      && rel.subitem_relation_type_id.subitem_relation_type_select === 'DOI') {
+    doiRelEntries.push({ index: i, doi: rel.subitem_relation_type_id.subitem_relation_type_id_text });
+  }
+});
+const relTitles = await Promise.all(doiRelEntries.map(e => fetchRelationTitleJaLC(e.doi)));
+doiRelEntries.forEach((e, i) => {
+  if (relTitles[i]) {
+    relations[e.index].subitem_relation_name = [{
+      subitem_relation_name_text: relTitles[i].title,
+      subitem_relation_name_language: relTitles[i].lang,
+    }];
+  }
+});
+```
+
+---
+
+## パフォーマンス考慮
+
+- relation 内の DOI 件数は通常 1〜3 件程度（`has-preprint`, `is-version-of` 等）
+- `Promise.all` で並列リクエストするため、追加待ち時間は最大 1 リクエスト分程度
+- エラー時は silent fail（null 返却）で既存動作に影響なし
+- 既に `mapToItemType()` / `mapToItemTypeJaLC()` 内で多数の API コールが行われているため、追加の影響は軽微
+
+---
+
+## 行番号インパクト
+
+| 修正箇所 | 追加行数目安 |
+|---|---|
+| `fetchRelationTitle()` 新設（~L1143） | +15行 |
+| `fetchRelationTitleJaLC()` 新設（~L1158） | +16行 |
+| `mapToItemType()` IIFE→async IIFE 化 | +1行 |
+| `mapToItemType()` DOI URL 統一 | +2行 |
+| `mapToItemType()` タイトル取得追加 | +13行 |
+| `mapToItemTypeJaLC()` フィールド名修正 + DOI URL 統一 | +2行 |
+| `mapToItemTypeJaLC()` タイトル取得追加 | +13行 |
+| **合計** | **~+62行** |
+
+---
+
+## 検証方法
+
+1. テスト用 DOI `10.1038/s41467-023-40773-1` でデータ取得
+2. 関連情報セクションを確認:
+   - `has-preprint` → `10.1101/2021.07.28.453724` が `https://doi.org/10.1101/2021.07.28.453724` として格納される
+   - `subitem_relation_name` にプレプリントのタイトルが設定される
+3. テスト用 DOI `10.1016/j.advnut.2025.100480` でもデータ取得し、relation がある場合に名称が設定されることを確認
+4. 関連 DOI が存在しない場合（404）、`subitem_relation_name` は空配列のまま（既存動作と同じ）
+
+---
+
+## ブランチ・PR
+
+- ブランチ: `feature/relation-improvement`
+- PR前更新: README.md、make_jc_importer.html (version-info)、docs/requirements.md、docs/worklog.md、MEMORY.md

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -227,7 +227,10 @@ make_jc_importer.html
             -   識別子タイプ："key": "item_30002_relation18[].subitem_relation_type_id.subitem_relation_type_select"
                 -   `CROSSREF_RELATION_ID_TYPE_MAP` でマッピングした JPCOAR identifierType 値
             -   関連識別子："key": "item_30002_relation18[].subitem_relation_type_id.subitem_relation_type_id_text"
-                -   Crossref `relation[*][*].id` の値
+                -   Crossref `relation[*][*].id` の値。`id-type` が DOI の場合は `https://doi.org/` プレフィックスを付与してURL形式に統一する
+            -   関連名称："key": "item_30002_relation18[].subitem_relation_name[]"
+                -   `isIdenticalTo` 以外の DOI タイプの関連エントリについて、Crossref API（Crossref DOI の場合）または JaLC API（JaLC DOI の場合）から関連DOIのタイトルを自動取得し設定する
+                -   取得失敗時は空配列のまま（silent fail）
 
 **Crossref `relation` フィールドの例**
 ```json

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-02-27（プレビュー機能）
+最終更新: 2026-03-01（関連情報の取得改善）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -8,7 +8,32 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 実装計画: `Implementation_phase1.md`
 対象ファイル: `make_jc_importer.html`（新規作成）
-現在のファイル規模: **約4450行**（STEP 1〜8 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング + ISBN/relation取り込み + JGN連携 + 識別子逆引き + JPCOAR 2.0 語彙対応 + JaLC API対応 + プレビュー機能）
+現在のファイル規模: **約4525行**（STEP 1〜8 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング + ISBN/relation取り込み + JGN連携 + 識別子逆引き + JPCOAR 2.0 語彙対応 + JaLC API対応 + プレビュー機能 + 関連情報取得改善）
+
+---
+
+## 2026-03-01: 関連情報の取得改善（issue #42）
+
+### 実装内容
+
+**Step 1: タイトル取得関数の新設（~L1145, L1161）**
+- `fetchRelationTitle(doi)`: Crossref API から関連DOIのタイトルと言語を取得。エラー時は null（silent fail）
+- `fetchRelationTitleJaLC(doi)`: JaLC API から関連DOIのタイトルと言語を取得。title_list の最初の1件を採用
+
+**Step 2: mapToItemType() の relation 部分修正（L1926）**
+- IIFE `(() => {...})()` → async IIFE `await (async () => {...})()` に変更（await 使用のため）
+- セクション4（Crossref relation エントリ）: DOI タイプの場合 `https://doi.org/` プレフィックスを付与してURL形式に統一
+- セクション5（新規追加）: isIdenticalTo 以外の DOI エントリを収集し、Promise.all で並列にタイトル取得して subitem_relation_name に設定
+
+**Step 3: mapToItemTypeJaLC() の relation 部分修正（L2197）**
+- JaLC API のフィールド名を実際のレスポンスに修正: `relation_type`→`relation`、`identifier_type`→`type`、`related_identifier||url`→`content`
+- DOI タイプの場合 `https://doi.org/` プレフィックスを付与
+- isIdenticalTo 以外の DOI エントリについて JaLC API（fetchRelationTitleJaLC）でタイトルを取得
+
+### 設計ポイント
+- fetchCrossref()/fetchJaLC() を再利用しない理由: 既存関数は 404 で throw するが、関連 DOI の取得失敗は正常系（silent fail）
+- isIdenticalTo は自身の DOI/OpenAlex IDs/ISBN のため名称取得対象外
+- JaLC DOI は Crossref に情報がないため JaLC API を使用
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -458,7 +458,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-02-27 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-03-01 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -470,6 +470,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-01</td>
+        <td style="padding:2px 0;">関連情報の取得改善：関連DOIのURL形式統一（https://doi.org/プレフィックス付与）、関連名称（タイトル）の自動取得、JaLC APIフィールド名修正</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-27</td>
         <td style="padding:2px 0;">プレビュー機能追加：入力済みメタデータをJAIRO Cloud風コンパクトテーブルでモーダル表示。collectFromDOM()によるDOM→JSON変換基盤を実装</td>
@@ -485,10 +489,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-25</td>
         <td style="padding:2px 0;">Crossref の受理日（accepted）・提出日（submitted）を日付フィールドに追加取得（Accepted / Submitted タイプ）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-24</td>
-        <td style="padding:2px 0;">JPCOAR 2.0 資源タイプ語彙対応：v2.0の31型（データセットサブタイプ・特許サブタイプ等）を RESOURCE_TYPE_MAP に追加、セレクトメニュー更新</td>
       </tr>
     </tbody>
   </table>
@@ -1139,6 +1139,39 @@ async function fetchJaLC(doi) {
   }
   const json = await resp.json();
   return json.data;
+}
+
+// ===== 3.2a 関連DOIタイトル取得（Crossref）=====
+async function fetchRelationTitle(doi) {
+  const bareDoi = doi.replace(/^https?:\/\/doi\.org\//i, '');
+  try {
+    const resp = await fetch(`https://api.crossref.org/works/${encodeURIComponent(bareDoi)}`);
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    const msg = data.message || {};
+    const title = (msg.title || [])[0] || '';
+    const lang = msg.language || 'en';
+    return title ? { title, lang } : null;
+  } catch {
+    return null;
+  }
+}
+
+// ===== 3.2b 関連DOIタイトル取得（JaLC）=====
+async function fetchRelationTitleJaLC(doi) {
+  const bareDoi = doi.replace(/^https?:\/\/doi\.org\//i, '');
+  try {
+    const resp = await fetch(`https://api.japanlinkcenter.org/v2/dois/${encodeURIComponent(bareDoi)}`, {
+      headers: { 'Accept': 'application/json' },
+    });
+    if (!resp.ok) return null;
+    const json = await resp.json();
+    const titles = (json.data || {}).title_list || [];
+    const first = titles[0];
+    return first?.title ? { title: first.title, lang: first.lang || 'ja' } : null;
+  } catch {
+    return null;
+  }
 }
 
 // ===== 3.3 ROR v2 API（単体） =====
@@ -1890,14 +1923,14 @@ async function mapToItemType(crJson, oaJson, rorMap) {
     item_30002_identifier_registration17: { subitem_identifier_reg_text: '', subitem_identifier_reg_type: '' },
 
     // ----- 関連情報 -----
-    item_30002_relation18: (() => {
+    item_30002_relation18: await (async () => {
       // relatedIdentifier.md に定義された識別子タイプ
       const VALID_RELATION_ID_TYPES = new Set([
         'ARK','ARXIV','DOI','HDL','ICHUSHI','ISBN','J-GLOBAL','LOCAL',
         'PISSN','EISSN','ISSN','NAID','NCID','PMID','PURL','SCOPUS','URI','WOS',
       ]);
       const relations = [];
-      // 1) Crossref DOI エントリ（テキストがないので subitem_relation_name: []）
+      // 1) Crossref DOI エントリ
       if (doi) {
         relations.push({
           subitem_relation_type: 'isIdenticalTo',
@@ -1957,15 +1990,34 @@ async function mapToItemType(crJson, oaJson, rorMap) {
           if (!jpcoarIdType) return;
           const id = item.id || '';
           if (!id) return;
+          const idText = jpcoarIdType === 'DOI' && !/^https?:\/\//i.test(id)
+            ? `https://doi.org/${id}` : id;
           relations.push({
             subitem_relation_type: jpcoarRelType,
             subitem_relation_type_id: {
-              subitem_relation_type_id_text: id,
+              subitem_relation_type_id_text: idText,
               subitem_relation_type_select: jpcoarIdType,
             },
             subitem_relation_name: [],
           });
         });
+      });
+      // 5) DOI タイプの関連エントリにタイトルを設定（isIdenticalTo は自身の識別子なので除外）
+      const doiRelEntries = [];
+      relations.forEach((rel, i) => {
+        if (rel.subitem_relation_type !== 'isIdenticalTo'
+            && rel.subitem_relation_type_id.subitem_relation_type_select === 'DOI') {
+          doiRelEntries.push({ index: i, doi: rel.subitem_relation_type_id.subitem_relation_type_id_text });
+        }
+      });
+      const relTitles = await Promise.all(doiRelEntries.map(e => fetchRelationTitle(e.doi)));
+      doiRelEntries.forEach((e, i) => {
+        if (relTitles[i]) {
+          relations[e.index].subitem_relation_name = [{
+            subitem_relation_name_text: relTitles[i].title,
+            subitem_relation_name_language: relTitles[i].lang,
+          }];
+        }
       });
       return relations;
     })(),
@@ -2143,17 +2195,36 @@ async function mapToItemTypeJaLC(jalcJson) {
     });
   }
   (jalcJson.relation_list || []).forEach(r => {
-    const relType = r.relation_type || '';
-    const idType  = r.identifier_type || '';
-    const id      = r.related_identifier || r.url || '';
+    const relType = r.relation || '';
+    const idType  = r.type || '';
+    const id      = r.content || '';
     if (!id) return;
     const jpcoarRelType = relType || 'isReferencedBy';
     const jpcoarIdType  = idType || 'URI';
+    const idText = jpcoarIdType === 'DOI' && !/^https?:\/\//i.test(id)
+      ? `https://doi.org/${id}` : id;
     relations.push({
       subitem_relation_type: jpcoarRelType,
-      subitem_relation_type_id: { subitem_relation_type_id_text: id, subitem_relation_type_select: jpcoarIdType },
+      subitem_relation_type_id: { subitem_relation_type_id_text: idText, subitem_relation_type_select: jpcoarIdType },
       subitem_relation_name: [],
     });
+  });
+  // DOI タイプの関連エントリにタイトルを設定（JaLC API 使用、isIdenticalTo は自身の識別子なので除外）
+  const doiRelEntries = [];
+  relations.forEach((rel, i) => {
+    if (rel.subitem_relation_type !== 'isIdenticalTo'
+        && rel.subitem_relation_type_id.subitem_relation_type_select === 'DOI') {
+      doiRelEntries.push({ index: i, doi: rel.subitem_relation_type_id.subitem_relation_type_id_text });
+    }
+  });
+  const relTitles = await Promise.all(doiRelEntries.map(e => fetchRelationTitleJaLC(e.doi)));
+  doiRelEntries.forEach((e, i) => {
+    if (relTitles[i]) {
+      relations[e.index].subitem_relation_name = [{
+        subitem_relation_name_text: relTitles[i].title,
+        subitem_relation_name_language: relTitles[i].lang,
+      }];
+    }
   });
 
   // ===== メタデータオブジェクト =====
@@ -4432,7 +4503,7 @@ if (!CONFIG.OpenAlex_API_KEY || CONFIG.OpenAlex_API_KEY === 'YOUR_OpenAlex_API_K
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-02-27';
+  const LOCAL_VERSION = '2026-03-01';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;


### PR DESCRIPTION
## Summary
- 関連DOIのURL形式を統一（`https://doi.org/` プレフィックス付与）
- 関連名称（タイトル）を自動取得（Crossrefパス→Crossref API、JaLCパス→JaLC API）
- JaLC API `relation_list` のフィールド名を実際のレスポンスに修正（`relation_type`→`relation`、`identifier_type`→`type`、`related_identifier`→`content`）

## 変更内容
| 箇所 | 内容 |
|------|------|
| `fetchRelationTitle()` 新設 | Crossref APIから関連DOIのタイトル・言語を取得（silent fail） |
| `fetchRelationTitleJaLC()` 新設 | JaLC APIから関連DOIのタイトル・言語を取得（silent fail） |
| `mapToItemType()` | IIFE→async IIFE化、DOI URL統一、isIdenticalTo以外のDOIエントリにタイトル設定 |
| `mapToItemTypeJaLC()` | フィールド名修正、DOI URL統一、タイトル取得 |

## Test plan
- [x] `10.1038/s41467-023-40773-1` でデータ取得 → 関連情報に `has-preprint` の DOI が `https://doi.org/` 形式で格納され、タイトルが設定されることを確認
- [x] `10.1016/j.advnut.2025.100480` でデータ取得 → relation がある場合に名称が設定されることを確認
- [x] 関連DOIが存在しない場合（404）→ `subitem_relation_name` は空配列のまま（既存動作維持）

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)