### PR TITLE
fix: PMID識別子のURL除去 (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ APIキーを設定するとレート制限が緩和されます。
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-02 | PMID識別子のURL除去：関連情報のidentifierType=PMID時にPubMed URLから番号のみを抽出し、IRDB登録エラーを回避（[#47](https://github.com/tzhaya/jc-import-file-maker/issues/47)） |
 | 2026-03-01 | 関連情報の取得改善：関連DOIのURL形式統一（`https://doi.org/`プレフィックス付与）、関連名称（タイトル）の自動取得（Crossref/JaLC API）、JaLC API relation_listフィールド名修正（[#42](https://github.com/tzhaya/jc-import-file-maker/issues/42)） |
 | 2026-02-27 | プレビュー機能追加：入力済みメタデータをJAIRO Cloud風コンパクトテーブルでモーダル表示。collectFromDOM()によるDOM→JSON変換基盤を実装（[#37](https://github.com/tzhaya/jc-import-file-maker/issues/37)） |
 | 2026-02-26 | JaLC API対応（準備中）：JaLC DOIからのメタデータ取得・マッピングコードを追加。CORS制約により未有効化（[#6](https://github.com/tzhaya/jc-import-file-maker/issues/6)） |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -214,6 +214,7 @@ make_jc_importer.html
             -   関連識別子："key": "item_30002_relation18[].subitem_relation_type_id.subitem_relation_type_id_text"
                 -   `key`に対する `value` の値
                 -   例：https://pubmed.ncbi.nlm.nih.gov/40653270
+                -   ただし `identifierType` が `PMID` の場合、IRDBは8桁までの数字のみを受け付けるため、PubMed URL プレフィックス（`https://pubmed.ncbi.nlm.nih.gov/`）を除去して番号のみ出力する
         -   Crossref APIの `isbn-type` / `ISBN` フィールドに含まれるISBNを関連情報に追加する（book 系資源タイプ固有）。`isbn-type` が存在する場合は優先し、なければ `ISBN` 配列にフォールバック。
             -   関連タイプ："key": "item_30002_relation18[].subitem_relation_type"
                 -   "value": "isIdenticalTo"
@@ -227,7 +228,7 @@ make_jc_importer.html
             -   識別子タイプ："key": "item_30002_relation18[].subitem_relation_type_id.subitem_relation_type_select"
                 -   `CROSSREF_RELATION_ID_TYPE_MAP` でマッピングした JPCOAR identifierType 値
             -   関連識別子："key": "item_30002_relation18[].subitem_relation_type_id.subitem_relation_type_id_text"
-                -   Crossref `relation[*][*].id` の値。`id-type` が DOI の場合は `https://doi.org/` プレフィックスを付与してURL形式に統一する
+                -   Crossref `relation[*][*].id` の値。`id-type` が DOI の場合は `https://doi.org/` プレフィックスを付与してURL形式に統一する。`id-type` が PMID の場合は PubMed URL プレフィックスを除去して番号のみ出力する
             -   関連名称："key": "item_30002_relation18[].subitem_relation_name[]"
                 -   `isIdenticalTo` 以外の DOI タイプの関連エントリについて、Crossref API（Crossref DOI の場合）または JaLC API（JaLC DOI の場合）から関連DOIのタイトルを自動取得し設定する
                 -   取得失敗時は空配列のまま（silent fail）

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-01（使い方ガイド追加）
+最終更新: 2026-03-02（PMID識別子URL除去）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -9,6 +9,27 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 実装計画: `Implementation_phase1.md`
 対象ファイル: `make_jc_importer.html`（新規作成）
 現在のファイル規模: **約4525行**（STEP 1〜8 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング + ISBN/relation取り込み + JGN連携 + 識別子逆引き + JPCOAR 2.0 語彙対応 + JaLC API対応 + プレビュー機能 + 関連情報取得改善）
+
+---
+
+## 2026-03-02: PMID識別子のURL除去（issue #47）
+
+### 問題
+
+関連情報のidentifierType=PMIDの場合、Crossref APIやOpenAlex APIがPubMed URL（`https://pubmed.ncbi.nlm.nih.gov/41617642`）を返すが、IRDBは8桁までの数字のみを期待する。URL形式のまま出力するとIRDBで「8桁までの数字以外の値が設定されています」エラーが発生する。
+
+### 実装内容
+
+**Crossref relation エントリ（L1993付近）**
+- `jpcoarIdType === 'PMID'` の場合、`id.replace(/^https?:\/\/pubmed\.ncbi\.nlm\.nih\.gov\//, '')` でURLプレフィックスを除去し番号のみを出力
+
+**OpenAlex ids エントリ（L1953付近）**
+- `upperKey === 'PMID'` の場合、同様のreplaceでURLプレフィックスを除去
+
+### 影響範囲
+- Crossrefパス: mapToItemType() 内のセクション4（Crossref relation エントリ）
+- OpenAlexパス: mapToItemType() 内のセクション2（OpenAlex ids エントリ）
+- JaLCパス: 影響なし（relation に PMID が出現しない）
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -458,7 +458,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-03-01 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-03-02 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -470,6 +470,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-02</td>
+        <td style="padding:2px 0;">PMID識別子のURL除去：関連情報のidentifierType=PMID時にPubMed URLから番号のみを抽出（IRDB登録エラー対応）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-01</td>
         <td style="padding:2px 0;">関連情報の取得改善：関連DOIのURL形式統一（https://doi.org/プレフィックス付与）、関連名称（タイトル）の自動取得、JaLC APIフィールド名修正</td>
@@ -485,10 +489,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-25</td>
         <td style="padding:2px 0;">GitHub最新コミットとの更新チェック機能追加、インデックスID入力欄をシステム管理フィールドに移行、更新概要を直近5件に制限</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-25</td>
-        <td style="padding:2px 0;">Crossref の受理日（accepted）・提出日（submitted）を日付フィールドに追加取得（Accepted / Submitted タイプ）</td>
       </tr>
     </tbody>
   </table>
@@ -1950,7 +1950,8 @@ async function mapToItemType(crJson, oaJson, rorMap) {
         relations.push({
           subitem_relation_type: 'isIdenticalTo',
           subitem_relation_type_id: {
-            subitem_relation_type_id_text: value,
+            subitem_relation_type_id_text: upperKey === 'PMID'
+              ? value.replace(/^https?:\/\/pubmed\.ncbi\.nlm\.nih\.gov\//, '') : value,
             subitem_relation_type_select: upperKey,
           },
           subitem_relation_name: [],
@@ -1991,7 +1992,10 @@ async function mapToItemType(crJson, oaJson, rorMap) {
           const id = item.id || '';
           if (!id) return;
           const idText = jpcoarIdType === 'DOI' && !/^https?:\/\//i.test(id)
-            ? `https://doi.org/${id}` : id;
+            ? `https://doi.org/${id}`
+            : jpcoarIdType === 'PMID'
+              ? id.replace(/^https?:\/\/pubmed\.ncbi\.nlm\.nih\.gov\//, '')
+              : id;
           relations.push({
             subitem_relation_type: jpcoarRelType,
             subitem_relation_type_id: {
@@ -4503,7 +4507,7 @@ if (!CONFIG.OpenAlex_API_KEY || CONFIG.OpenAlex_API_KEY === 'YOUR_OpenAlex_API_K
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-03-01';
+  const LOCAL_VERSION = '2026-03-02';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;


### PR DESCRIPTION
## Summary

- 関連情報の `identifierType=PMID` 時に、PubMed URL（`https://pubmed.ncbi.nlm.nih.gov/41617642`）から番号のみ（`41617642`）を抽出するよう修正
- Crossref relation エントリ・OpenAlex ids エントリの2箇所を修正
- IRDBの「8桁までの数字以外の値が設定されています」登録エラーを回避

Closes #47

## Test plan

- [x] PMID を含む関連情報を持つ DOI でデータ取得し、関連情報の識別子が番号のみになっていることを確認
- [x] DOI タイプの関連情報が従来通り `https://doi.org/` プレフィックス付きで出力されることを確認
- [x] その他の識別子タイプ（ISBN, ISSN, URI 等）が影響を受けていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)