### PR TITLE
feat: KAKEN/JGN番号から助成機関名・Funder ID自動設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ APIキーを設定するとレート制限が緩和されます。
 - NCID自動取得：ISSNからCiNii Research OpenSearch APIでNCIDを取得し収録物識別子に追加（CiNii書誌ページへの参照リンク付き）
 - Crossref ISBN・relation フィールドの関連情報への取り込み：book系でISBNをisIdenticalTo/ISBNとして追加、全資源タイプでCrossref relationフィールドのエントリを関連情報に追加
 - JGN（Japan Grant Number）連携：award が `JP` で始まる場合に Crossref JGN API（prefix `10.52926`）を照会し、JST助成金の課題名（日英）と課題DOI URIを自動取得。JGN未登録の場合は既存のKAKEN連携（JSPS科研費）にフォールバック
+- KAKEN/JGN番号からの助成機関自動設定：課題番号からJGN/KAKEN APIで助成機関名・Crossref Funder IDを自動補完。UIの「助成機関を検索」ボタンで手動入力時も逆引き可能
 - 識別子からの機関名逆引き
   - 所属機関識別子（ROR）・助成機関識別子（ROR / Crossref Funder）を入力すると「名称を確認」ボタンが表示されます。
   - ボタンを押すと、APIから名称を取得します。「上書き」ボタンを押して現在の内容を置き換えることができます。
@@ -121,6 +122,7 @@ APIキーを設定するとレート制限が緩和されます。
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-03 | KAKEN/JGN番号から助成機関名・Crossref Funder IDを自動設定。研究課題番号入力欄に「助成機関を検索」ボタンを追加し、手動入力時もJGN/KAKEN APIから助成機関情報を逆引き可能に（[#52](https://github.com/tzhaya/jc-import-file-maker/issues/52)） |
 | 2026-03-02 | PMID識別子のURL除去：関連情報のidentifierType=PMID時にPubMed URLから番号のみを抽出し、IRDB登録エラーを回避（[#47](https://github.com/tzhaya/jc-import-file-maker/issues/47)） |
 | 2026-03-01 | 関連情報の取得改善：関連DOIのURL形式統一（`https://doi.org/`プレフィックス付与）、関連名称（タイトル）の自動取得（Crossref/JaLC API）、JaLC API relation_listフィールド名修正（[#42](https://github.com/tzhaya/jc-import-file-maker/issues/42)） |
 | 2026-02-27 | プレビュー機能追加：入力済みメタデータをJAIRO Cloud風コンパクトテーブルでモーダル表示。collectFromDOM()によるDOM→JSON変換基盤を実装（[#37](https://github.com/tzhaya/jc-import-file-maker/issues/37)） |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -431,6 +431,7 @@ ItemType.json には複数レベルのネスト構造を持つフィールドが
 - award番号が `JP` で始まる場合、Crossref の JGN（Japan Grant Number）API（`https://api.crossref.org/works/10.52926/{award}`）を照会する
 - レスポンスが `type: "grant"` の場合のみ処理実行
 - `project[0].project-title[].title` を課題名、`.language` を言語として `subitem_award_titles[]` に設定
+- `funder[0].name` を助成機関名、`funder[0].DOI` を助成機関識別子として返す（助成機関名・識別子が空の場合に補完）
 - `https://doi.org/10.52926/{award}` を `subitem_award_uri` に設定
 - 404（JGN未登録）の場合は null を返し、KAKEN連携にフォールバック
 - JGN連携が成功した場合、KAKEN連携はスキップ
@@ -443,8 +444,15 @@ ItemType.json には複数レベルのネスト構造を持つフィールドが
 - 日本語・英語の課題名を並列取得し、`subitem_award_titles[]` に設定
   - 日英タイトルが同一の場合は日本語のみ設定
 - KAKEN 課題ページ URL を `subitem_award_uri` に設定
+- KAKEN成功時、助成機関名・識別子が空の場合はJSPS定数（日本学術振興会/Japan Society for the Promotion of Science、DOI: `10.13039/501100001691`）で補完
 - CiNii API がエラーの場合は警告のみ出力し、Crossref データを保持（フォールバック）
 - JSPS以外の funder、award番号が空、またはJGN連携成功済みの場合はKAKEN連携をスキップ
+
+**研究課題番号からの助成機関検索（UI）**:
+- 助成情報の研究課題番号入力欄に「助成機関を検索」ボタンを表示
+- クリック時: 入力された課題番号でJGN API → KAKEN APIの順に検索
+- 成功時: 助成機関名・助成機関識別子・研究課題名・研究課題番号URIを一括設定
+- JGN成功時はレスポンスのfunder情報、KAKEN成功時はJSPS固定値を使用
 
 **識別子からの機関名逆引き（ROR / Crossref Funders API）**:
 - 所属機関識別子セクション: Scheme が「ROR」の場合に「名称を確認」ボタンを表示し、URI フィールドの値を使って ROR v2 API から機関名（`ror_display` + `label` タイプ）を取得

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-02（PMID識別子URL除去）
+最終更新: 2026-03-03（KAKEN/JGN番号から助成機関名・Funder ID自動設定）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -9,6 +9,38 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 実装計画: `Implementation_phase1.md`
 対象ファイル: `make_jc_importer.html`（新規作成）
 現在のファイル規模: **約4525行**（STEP 1〜8 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング + ISBN/relation取り込み + JGN連携 + 識別子逆引き + JPCOAR 2.0 語彙対応 + JaLC API対応 + プレビュー機能 + 関連情報取得改善）
+
+---
+
+## 2026-03-03: KAKEN/JGN番号から助成機関名・Crossref Funder ID自動設定（issue #52）
+
+### 背景
+
+KAKEN/JGN連携で研究課題名とURIは取得していたが、助成機関名とCrossref Funder IDは設定されていなかった。JaLCパスやユーザー手動入力時に助成機関情報が空のままになるケースがあった。
+
+### 実装内容
+
+**JSPS定数のグローバル化**
+- `JSPS_FUNDER_DOI`（`10.13039/501100001691`）と `JSPS_FUNDER_NAMES`（日英）をグローバル定数として定義
+- `buildFunders()` / `buildJaLCFunders()` のローカル `JSPS_DOI` を統合
+
+**`fetchJgn()` の拡張**
+- JGN Crossrefレスポンスの `funder` 配列から助成機関名（`funder[0].name`）とDOI（`funder[0].DOI`）を抽出
+- 返り値に `funderNames` と `funderDoi` を追加
+
+**`fetchKaken()` の返り値統一**
+- `fetchJgn()` と同じ形式に統一（`funderNames: [], funderDoi: ''` を追加）
+
+**`buildFunders()` / `buildJaLCFunders()` の修正**
+- KAKEN/JGN結果がある場合に、助成機関名と識別子が空なら自動補完
+- JGN成功時: JGNレスポンスのfunder情報を使用
+- KAKEN成功時: JSPS定数を使用
+- 既存値がある場合は上書きしない（Crossref/JaLC元データ優先）
+
+**UI: 「助成機関を検索」ボタン**
+- `renderOneFunder()` 内の研究課題番号入力欄に「助成機関を検索」ボタンを追加
+- クリック時: JGN → KAKEN の順に試行し、助成機関名・識別子・課題名・URIをフォーム全体に設定
+- 結果表示は既存の `lookup-result` スタイルを使用
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -458,7 +458,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-03-02 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-03-03 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -470,6 +470,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-03</td>
+        <td style="padding:2px 0;">KAKEN/JGN番号から助成機関名・Crossref Funder IDを自動設定、研究課題番号からの助成機関検索ボタン追加</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-02</td>
         <td style="padding:2px 0;">PMID識別子のURL除去：関連情報のidentifierType=PMID時にPubMed URLから番号のみを抽出（IRDB登録エラー対応）</td>
@@ -485,10 +489,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-26</td>
         <td style="padding:2px 0;">JaLC API対応（準備中）：JaLC DOIからのメタデータ取得・マッピングコードを追加（CORS制約により未有効化）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-02-25</td>
-        <td style="padding:2px 0;">GitHub最新コミットとの更新チェック機能追加、インデックスID入力欄をシステム管理フィールドに移行、更新概要を直近5件に制限</td>
       </tr>
     </tbody>
   </table>
@@ -761,6 +761,13 @@ const VERSION_TYPE_MAP = {
   'EVoR': 'http://purl.org/coar/version/c_dc82b40f9837b551',
   'NA':   'http://purl.org/coar/version/c_be7fb7dd8ff6fe43',
 };
+
+// ===== JSPS 助成機関定数 =====
+const JSPS_FUNDER_DOI = '10.13039/501100001691';
+const JSPS_FUNDER_NAMES = [
+  { subitem_funder_name: '日本学術振興会',                                  subitem_funder_name_language: 'ja' },
+  { subitem_funder_name: 'Japan Society for the Promotion of Science', subitem_funder_name_language: 'en' },
+];
 
 // ===== アクセス権マッピング =====
 const ACCESS_RIGHTS_MAP = {
@@ -1280,7 +1287,7 @@ async function fetchKaken(awardNumber) {
     titles.push({ subitem_award_title: enTitle, subitem_award_title_language: 'en' });
   }
 
-  return { titles, kakenUrl };
+  return { titles, kakenUrl, funderNames: [], funderDoi: '' };
 }
 
 // ===== 3.5.2 Crossref JGN（Japan Grant Number）API =====
@@ -1301,7 +1308,14 @@ async function fetchJgn(awardNumber) {
         subitem_award_title_language: t.language || '',
       }));
 
-    return { titles, kakenUrl: `https://doi.org/10.52926/${awardNumber}` };
+    // 助成機関情報を抽出
+    const funder = item.funder?.[0];
+    const funderNames = funder?.name
+      ? [{ subitem_funder_name: funder.name, subitem_funder_name_language: 'en' }]
+      : [];
+    const funderDoi = funder?.DOI || '';
+
+    return { titles, kakenUrl: `https://doi.org/10.52926/${awardNumber}`, funderNames, funderDoi };
   } catch {
     return null;
   }
@@ -1618,15 +1632,13 @@ function buildJaLCAuthors(jalcCreators) {
 
 // ===== 4.4 助成情報マッピング =====
 async function buildFunders(crFunders) {
-  const JSPS_DOI = '10.13039/501100001691';
-
   const entries = await Promise.all((crFunders || []).map(async (f) => {
     const name      = f.name  || '';
     const funderDoi = f.DOI   || '';
     const awards    = f.award || [];
 
     // JSPS判定: funder DOI が JSPS（APIキー不要）
-    const isJsps = funderDoi === JSPS_DOI;
+    const isJsps = funderDoi === JSPS_FUNDER_DOI;
 
     const buildEntry = async (awardNum) => {
       const obj = {};
@@ -1662,6 +1674,22 @@ async function buildFunders(crFunders) {
         }
       }
 
+      // KAKEN/JGN 結果から助成機関名・識別子を補完（既存値がある場合は上書きしない）
+      if (kakenResult) {
+        if (!obj.subitem_funder_names.length) {
+          obj.subitem_funder_names = kakenResult.funderNames?.length
+            ? kakenResult.funderNames
+            : JSPS_FUNDER_NAMES.map(n => ({...n}));
+        }
+        if (!obj.subitem_funder_identifiers.subitem_funder_identifier) {
+          const doi = kakenResult.funderDoi || JSPS_FUNDER_DOI;
+          obj.subitem_funder_identifiers = {
+            subitem_funder_identifier:      `https://doi.org/${doi}`,
+            subitem_funder_identifier_type: 'Crossref Funder',
+          };
+        }
+      }
+
       obj.subitem_award_numbers = {
         subitem_award_number:      awardNum,
         subitem_award_number_type: '',
@@ -1681,8 +1709,6 @@ async function buildFunders(crFunders) {
 
 // ===== 4.4b JaLC 助成情報マッピング =====
 async function buildJaLCFunders(jalcFundList) {
-  const JSPS_DOI = '10.13039/501100001691';
-
   const entries = await Promise.all((jalcFundList || []).map(async (f) => {
     // 助成機関名（多言語）
     const funderNames = (f.funder_name || []).map(fn => ({
@@ -1699,7 +1725,7 @@ async function buildJaLCFunders(jalcFundList) {
         if (m) funderDoi = m[1];
       }
     });
-    const isJsps = funderDoi === JSPS_DOI;
+    const isJsps = funderDoi === JSPS_FUNDER_DOI;
 
     const funderIdentifiers = funderDoi
       ? { subitem_funder_identifier: `https://doi.org/${funderDoi}`, subitem_funder_identifier_type: 'Crossref Funder' }
@@ -1733,6 +1759,22 @@ async function buildJaLCFunders(jalcFundList) {
       if (isJsps && awardNum && !kakenResult) {
         try { kakenResult = await fetchKaken(awardNum); } catch (e) {
           console.warn(`KAKEN取得失敗 (${awardNum}):`, e.message);
+        }
+      }
+
+      // KAKEN/JGN 結果から助成機関名・識別子を補完（既存値がある場合は上書きしない）
+      if (kakenResult) {
+        if (!obj.subitem_funder_names.length) {
+          obj.subitem_funder_names = kakenResult.funderNames?.length
+            ? kakenResult.funderNames
+            : JSPS_FUNDER_NAMES.map(n => ({...n}));
+        }
+        if (!obj.subitem_funder_identifiers.subitem_funder_identifier) {
+          const doi = kakenResult.funderDoi || JSPS_FUNDER_DOI;
+          obj.subitem_funder_identifiers = {
+            subitem_funder_identifier:      `https://doi.org/${doi}`,
+            subitem_funder_identifier_type: 'Crossref Funder',
+          };
         }
       }
 
@@ -3305,9 +3347,14 @@ function renderOneFunder(funder, idx, defLabel) {
   });
   updateFunderLookup = updateFV;
 
-  // 研究課題番号（fieldset）
+  // 研究課題番号（fieldset）+ 助成機関を検索ボタン
   const aw = funder.subitem_award_numbers || {};
-  fundContent.appendChild(createFieldRow('研究課題番号', aw.subitem_award_number || '', 'text', null, { fieldKey: 'subitem_award_number' }));
+  const awardRow = createFieldRow('研究課題番号', aw.subitem_award_number || '', 'text', null, { fieldKey: 'subitem_award_number' });
+  const awardLookupBtn = document.createElement('button');
+  awardLookupBtn.textContent = '助成機関を検索';
+  awardLookupBtn.className = 'btn-add';
+  awardRow.appendChild(awardLookupBtn);
+  fundContent.appendChild(awardRow);
   fundContent.appendChild(createFieldRow('研究課題番号URI', aw.subitem_award_uri || '', 'text', null, { fieldKey: 'subitem_award_uri' }));
 
   // 研究課題名（配列）
@@ -3326,6 +3373,87 @@ function renderOneFunder(funder, idx, defLabel) {
     atCont.appendChild(grp);
   });
   fundContent.appendChild(atWrap);
+
+  // 助成機関を検索ボタンの結果表示エリアとイベントハンドラ
+  const awardResultEl = document.createElement('div');
+  awardResultEl.className = 'lookup-result';
+  fundContent.appendChild(awardResultEl);
+
+  awardLookupBtn.onclick = async (e) => {
+    e.preventDefault();
+    const awardInput = fundContent.querySelector('[data-field-key="subitem_award_number"] input');
+    const awardNum = awardInput?.value.trim() || '';
+    if (!awardNum) return;
+
+    awardLookupBtn.disabled = true;
+    awardResultEl.className = 'lookup-result';
+    awardResultEl.textContent = '検索中...';
+    try {
+      // JGN → KAKEN の順に試行
+      let result = null;
+      if (/^JP/i.test(awardNum)) {
+        try { result = await fetchJgn(awardNum); } catch { /* ignore */ }
+      }
+      if (!result) {
+        try { result = await fetchKaken(awardNum); } catch { /* ignore */ }
+      }
+
+      if (!result) {
+        awardResultEl.className = 'lookup-result warn';
+        awardResultEl.textContent = '⚠ 助成情報が見つかりませんでした。';
+        return;
+      }
+
+      // 助成機関名を設定
+      const names = result.funderNames?.length
+        ? result.funderNames
+        : JSPS_FUNDER_NAMES.map(n => ({...n}));
+      [...fnCont.querySelectorAll(':scope > .entry-group')].forEach(g => g.remove());
+      names.forEach(({ subitem_funder_name: nm, subitem_funder_name_language: lang }) => {
+        const { grp, delBtn } = createEntryGroup();
+        grp.appendChild(createFieldRow('助成機関名', nm, 'text', null, { fieldKey: 'subitem_funder_name' }));
+        grp.appendChild(createFieldRow('言語', lang || 'en', 'select', 'language', { fieldKey: 'subitem_funder_name_language' }));
+        grp.appendChild(delBtn);
+        fnCont.appendChild(grp);
+      });
+
+      // 助成機関識別子を設定
+      const doi = result.funderDoi || JSPS_FUNDER_DOI;
+      const idInput = fundContent.querySelector('[data-field-key="subitem_funder_identifier"] input');
+      const typeSelect = fundContent.querySelector('[data-field-key="subitem_funder_identifier_type"] select');
+      if (idInput) idInput.value = `https://doi.org/${doi}`;
+      if (typeSelect) typeSelect.value = 'Crossref Funder';
+      updateFunderLookup();
+
+      // 研究課題名を設定
+      if (result.titles?.length) {
+        [...atCont.querySelectorAll(':scope > .entry-group')].forEach(g => g.remove());
+        result.titles.forEach(({ subitem_award_title: t, subitem_award_title_language: lang }) => {
+          const { grp, delBtn } = createEntryGroup();
+          grp.appendChild(createFieldRow('研究課題名', t, 'text', null, { fieldKey: 'subitem_award_title' }));
+          grp.appendChild(createFieldRow('言語', lang || '', 'select', 'language', { fieldKey: 'subitem_award_title_language' }));
+          grp.appendChild(delBtn);
+          atCont.appendChild(grp);
+        });
+      }
+
+      // 研究課題番号URIを設定
+      const uriInput = fundContent.querySelector('[data-field-key="subitem_award_uri"] input');
+      if (uriInput && result.kakenUrl) uriInput.value = result.kakenUrl;
+
+      // ヘッダーラベルを更新
+      const headerSpan = fundItem.querySelector('.nested-item-header span:last-child');
+      if (headerSpan) {
+        const newName = names[0]?.subitem_funder_name || '';
+        headerSpan.textContent = `${defLabel}[${idx}]${newName ? ': '+newName.substring(0,40) : ''}`;
+      }
+
+      awardResultEl.className = 'lookup-result ok';
+      awardResultEl.textContent = '✓ 設定完了: ' + names.map(n => n.subitem_funder_name).join(', ');
+    } finally {
+      awardLookupBtn.disabled = false;
+    }
+  };
 
   return fundItem;
 }
@@ -4507,7 +4635,7 @@ if (!CONFIG.OpenAlex_API_KEY || CONFIG.OpenAlex_API_KEY === 'YOUR_OpenAlex_API_K
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-03-02';
+  const LOCAL_VERSION = '2026-03-03';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;


### PR DESCRIPTION
## Summary

Closes #52

- KAKEN/JGN番号から助成機関名・Crossref Funder IDを自動設定する機能を追加
- 研究課題番号入力欄に「助成機関を検索」ボタンを追加し、手動入力時もJGN/KAKENから逆引き可能に
- `JSPS_FUNDER_DOI` / `JSPS_FUNDER_NAMES` をグローバル定数化し、重複定義を解消

## 変更内容

- **JSPS定数のグローバル化**: `buildFunders()` / `buildJaLCFunders()` のローカル `JSPS_DOI` を `JSPS_FUNDER_DOI` に統合
- **`fetchJgn()` 拡張**: JGN Crossrefレスポンスから `funder[0].name` / `funder[0].DOI` も抽出して返却
- **`fetchKaken()` 返り値統一**: `fetchJgn()` と同じ形式（`funderNames`, `funderDoi` フィールド追加）
- **`buildFunders()` / `buildJaLCFunders()` 修正**: KAKEN/JGN結果がある場合、助成機関名・識別子が空なら自動補完（既存値は上書きしない）
- **UI: 「助成機関を検索」ボタン**: `renderOneFunder()` 内の研究課題番号入力欄に追加。JGN→KAKENの順に試行し、助成機関名・識別子・課題名・URIを一括設定

## Test plan

- [x] テストDOI `10.1016/j.advnut.2025.100480` で取得 → Crossrefパスでfunder情報が既にある場合は上書きされないことを確認
- [x] 手動で助成情報を追加し、課題番号 `JP21K05476` を入力 → 「助成機関を検索」ボタンでJSPSの名称・ID・課題名・URIが設定されることを確認
- [x] JGN登録済み番号 `JPMJPR2125` で「助成機関を検索」→ JST (Japan Science and Technology Agency) のfunder情報が取得されることを確認
- [x] JGN登録済み番号 `JPMJSA1907` でも同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)