### PR TITLE
feat: funder_lookup.html にプログラム情報識別子自動設定・Ack抽出を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ APIキーを設定するとレート制限が緩和されます。
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-03 | 助成情報検索ツール拡張：JGN課題番号からプログラム情報識別子（JGN_fundingStream）を自動設定、Acknowledgementsテキストからの課題番号自動抽出モードを追加（[#56](https://github.com/tzhaya/jc-import-file-maker/issues/56)） |
 | 2026-03-03 | 助成情報検索ツール（`funder_lookup.html`）を新規作成。課題番号からJPCOAR 2.0準拠の助成情報（助成機関識別子・助成機関名・プログラム情報・研究課題名）を一括検索（[#54](https://github.com/tzhaya/jc-import-file-maker/issues/54)） |
 | 2026-03-03 | KAKEN/JGN番号から助成機関名・Crossref Funder IDを自動設定。研究課題番号入力欄に「助成機関を検索」ボタンを追加し、手動入力時もJGN/KAKEN APIから助成機関情報を逆引き可能に（[#52](https://github.com/tzhaya/jc-import-file-maker/issues/52)） |
 | 2026-03-02 | PMID識別子のURL除去：関連情報のidentifierType=PMID時にPubMed URLから番号のみを抽出し、IRDB登録エラーを回避（[#47](https://github.com/tzhaya/jc-import-file-maker/issues/47)） |

--- a/docs/Implementation_funder_lookup.md
+++ b/docs/Implementation_funder_lookup.md
@@ -34,9 +34,10 @@ issue #53 で実装済みの `fetchJgn()` / `fetchKaken()` の機能を活用し
 |-----------|------------|-------------|
 | 助成機関識別子 | 23-.1 | JGN: `funding.funder.id[].id` / KAKEN: JSPS定数 |
 | 助成機関名 | 23-.2 | JGN: `funding.funder.name` / KAKEN: JSPS定数 |
-| プログラム情報識別子 | 23-.3 | 常に空欄（JGN APIから取得不可） |
+| プログラム情報識別子 | 23-.3 | JGN: 課題番号から JGN_fundingStream コードを自動抽出（#56） |
 | プログラム情報 | 23-.4 | JGN: `funding.scheme` / KAKEN: 科学研究費助成事業（定数） |
 | 研究課題番号 | 23-.5 | 入力値 |
+| 研究課題番号URI | 23-.5 | JGN: `https://doi.org/10.52926/{番号}` / KAKEN: CiNii Research URL |
 | 研究課題名 | 23-.5 | JGN: `project-title` / KAKEN: CiNii Research API |
 
 ### 移植・新規コード
@@ -58,3 +59,76 @@ issue #53 で実装済みの `fetchJgn()` / `fetchKaken()` の機能を活用し
   - `JP21H01234` / `21H01234`（KAKEN科研費番号 — JP付き/なし）
   - `JPMJSA1907`（JGN JST番号 — funder情報が `project.funding` 内にある例）
   - 存在しない番号（エラーハンドリング確認）
+
+---
+
+## 拡張: プログラム情報識別子自動設定 + Acknowledgements課題番号抽出（#56）
+
+> **ステータス: 実装完了（2026-03-03）**
+
+### 背景
+
+issue #34 の調査で、JPCOAR 2.0 の「プログラム情報識別子」(`fundingStreamIdentifier`) に `JGN_fundingStream` タイプが定義されていることが判明。JGN の課題番号には [NISTEP 体系的番号](https://www.nistep.go.jp/taikei) のプログラムコードが埋め込まれており、自動抽出が可能。
+
+### 機能A: プログラム情報識別子（fundingStreamIdentifier）の自動設定
+
+#### 体系的番号の構造
+
+| 課題番号 | 分解 | JGN_fundingStream コード |
+|---|---|---|
+| JPMJPR2125 | JP + **MJPR** + 2125 | MJPR（さきがけ/PRESTO） |
+| JPMJSA1907 | JP + **MJSA** + 1907 | MJSA（SATREPS） |
+| JPMJMS0001 | JP + **MJMS** + 0001 | MJMS（ムーンショット） |
+
+#### 実装
+
+- `fetchJgn()`: 正規表現 `/^JP([A-Z]+)\d/i` で JP 直後のアルファベット部分を抽出し `fundingStreamId` として返却
+- `lookupOne()`: JGN 結果に `fundingStreamId` / `fundingStreamIdType: 'JGN_fundingStream'` を追加
+- `buildResultCards()`: プログラム情報識別子行にコードとタイプを表示
+- 科研費番号（`JP21H01234` 等）は JP 直後が数字のため抽出されない（空欄のまま）
+
+#### Crossref Funder タイプについて
+
+`fundingStreamIdentifierType` には `Crossref Funder`（子プログラムの Funder DOI）も定義されているが、以下の理由で現時点では対応しない:
+- Crossref Funder Registry の `hierarchy-names` は英語名のみ、JGN の `scheme` は日本語で言語マッチング困難
+- 全 descendants の個別 API 呼び出し（JST で37件）は負荷が大きい
+
+#### Crossref Funder Registry の階層例（JST）
+
+| レベル | Funder DOI | 名称 | JPCOAR 項目 |
+|---|---|---|---|
+| 親 | `10.13039/501100001700` | MEXT（文部科学省） | ― |
+| 子 | `10.13039/501100002241` | JST（科学技術振興機構） | 助成機関識別子 |
+| 孫 | `10.13039/501100009023` | さきがけ / PRESTO | プログラム情報識別子 |
+| ひ孫 | Crossref DOI type `grant` | 個別の研究課題 | 研究課題番号 |
+
+### 機能B: Acknowledgementsテキストからの課題番号自動抽出
+
+#### 実装
+
+- ラジオボタンで「課題番号」/「Acknowledgementsテキスト」モードを切替
+- `updatePlaceholder()`: モードに応じてラベル・placeholder・ヒント文を動的切替
+- `doSearch()`: Ack モード時は `/JP[A-Za-z0-9]+/g` で課題番号を抽出（`Set` で重複排除）
+- 課題番号モードは従来通り改行区切り
+
+#### エラー時の NISTEP リンク表示
+
+- `lookupOne()`: JP で始まり英字を含む番号（`/^JP[A-Z]/i`）で JGN・KAKEN いずれも見つからなかった場合、エラーカードに[最新の体系的番号一覧（NISTEP）](https://www.nistep.go.jp/taikei/)へのリンクを表示
+- `nistepHint` プロパティとして HTML リンクを返し、`buildResultCards()` でエスケープせずに挿入
+- 科研費番号（JP + 数字で始まるもの）やJP接頭辞のない番号ではリンク非表示
+
+### 検証方法
+
+#### 機能A: fundingStreamIdentifier
+- `JPMJPR2125` → プログラム情報識別子: `MJPR` (JGN_fundingStream) が表示
+- `JPMJSA1907` → プログラム情報識別子: `MJSA` (JGN_fundingStream) が表示
+- `21K12345` → KAKEN 結果、プログラム情報識別子: 空欄
+- `JP21H01234` → KAKEN 結果、プログラム情報識別子: 空欄
+
+#### 機能B: Acknowledgements 抽出
+- Ack モードで以下のテキストを貼り付けて検索:
+  ```
+  This work was supported by ... (Grant Nos. JP18K05379 to Y.N.; JP21H02158 to Y.N., Y.F.; JP16K07412, JP24510312 to Y.F.), ... (Grant No. JPJ009237), ... (Grant No. JPMJSA1907) ...
+  ```
+- 6件の課題番号が抽出・検索されること: JP18K05379, JP21H02158, JP16K07412, JP24510312, JPJ009237, JPMJSA1907
+- 重複排除されること

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-03（助成情報検索ツール新規作成）
+最終更新: 2026-03-03（助成情報検索ツール拡張: プログラム情報識別子自動設定・Acknowledgements抽出）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -9,6 +9,27 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 実装計画: `Implementation_phase1.md`
 対象ファイル: `make_jc_importer.html`（新規作成）
 現在のファイル規模: **約4525行**（STEP 1〜8 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング + ISBN/relation取り込み + JGN連携 + 識別子逆引き + JPCOAR 2.0 語彙対応 + JaLC API対応 + プレビュー機能 + 関連情報取得改善）
+
+---
+
+## 2026-03-03: 助成情報検索ツール拡張 — プログラム情報識別子自動設定・Acknowledgements抽出（issue #56）
+
+### 背景
+
+issue #34 の調査で、JPCOAR 2.0 の「プログラム情報識別子」に `JGN_fundingStream` タイプが定義されていること、JGN課題番号にNISTEP体系的番号のプログラムコードが埋め込まれていることが判明。また、論文のAcknowledgementsテキストから課題番号を自動抽出する需要を確認。
+
+### 実装内容
+
+**機能A: プログラム情報識別子（fundingStreamIdentifier）の自動設定**
+- `fetchJgn()`: 正規表現 `/^JP([A-Z]+)\d/i` で課題番号からJGN_fundingStreamコードを抽出（例: JPMJPR2125 → MJPR）
+- `lookupOne()`: JGN結果に `fundingStreamId` / `fundingStreamIdType: 'JGN_fundingStream'` を追加
+- `buildResultCards()`: プログラム情報識別子行にコードとタイプを表示
+- 科研費番号はJP直後が数字のため空欄のまま
+
+**機能B: Acknowledgementsテキストからの課題番号自動抽出**
+- ラジオボタンで「課題番号」/「Acknowledgementsテキスト」入力モードを切替
+- `updatePlaceholder()`: モードに応じてラベル・placeholder・ヒント文を動的切替
+- `doSearch()`: Ackモード時は `/JP[A-Za-z0-9]+/g` で課題番号を抽出（Setで重複排除）
 
 ---
 

--- a/funder_lookup.html
+++ b/funder_lookup.html
@@ -138,18 +138,24 @@
 <h1>助成情報検索ツール</h1>
 
 <div class="input-section">
-  <label for="award-input">課題番号を1行に1つ、改行して入力してください。</label>
+  <div style="margin-bottom:6px;font-size:0.9em">
+    <label style="display:inline;font-weight:normal"><input type="radio" name="input-mode" value="numbers" checked onchange="updatePlaceholder()"> 課題番号（1行に1つ）</label>
+    <label style="display:inline;font-weight:normal;margin-left:12px"><input type="radio" name="input-mode" value="ack" onchange="updatePlaceholder()"> Acknowledgementsテキストから抽出</label>
+  </div>
+  <label for="award-input" id="input-label">課題番号を1行に1つ、改行して入力してください。</label>
   <textarea id="award-input" placeholder="JP21H01234&#10;JPMJSA1907&#10;21K12345"></textarea>
-  <div class="hint">科研費課題番号（JP付き / なし）や JGN 課題番号を入力できます。</div>
+  <div class="hint" id="input-hint">科研費課題番号（JP付き / なし）や JGN 課題番号を入力できます。</div>
   <button class="btn" id="search-btn" onclick="doSearch()">検索</button>
 </div>
 <div class="hint">
-<p>科研費課題番号、JGN課題番号から助成情報の入力に必要な以下の情報を検索します。ただし、プログラム情報識別子は空欄となります。</p>
+<p>科研費課題番号、JGN課題番号から助成情報の入力に必要な以下の情報を検索します。</p>
 <ul>
   <li><a href="https://schema.irdb.nii.ac.jp/ja/schema/2.0/23-.1">助成機関識別子</a></li>
   <li><a href="https://schema.irdb.nii.ac.jp/ja/schema/2.0/23-.2">助成機関名</a></li>
-  <li><a href="https://schema.irdb.nii.ac.jp/ja/schema/2.0/23-.3">プログラム情報識別子(空欄で表示します)</a></li>
+  <li><a href="https://schema.irdb.nii.ac.jp/ja/schema/2.0/23-.3">プログラム情報識別子</a>（JGN課題番号の場合、<a href="https://www.nistep.go.jp/taikei">体系的番号</a>から自動抽出）</li>
   <li><a href="https://schema.irdb.nii.ac.jp/ja/schema/2.0/23-.4">プログラム情報</a></li>
+  <li><a href="https://schema.irdb.nii.ac.jp/ja/schema/2.0/23-.5">研究課題番号</a></li>
+  <li><a href="https://schema.irdb.nii.ac.jp/ja/schema/2.0/23-.5">研究課題番号URI</a></li>
   <li><a href="https://schema.irdb.nii.ac.jp/ja/schema/2.0/23-.5">研究課題名</a></li>
 </ul>
 <p>これらの項目に入力すべき情報の詳細は <a href="https://schema.irdb.nii.ac.jp/ja/schema/2.0/23">JPCOARスキーマガイドライン 2.0 「助成情報」</a>をご覧ください。</p>
@@ -219,7 +225,12 @@ async function fetchJgn(awardNumber) {
       ? [{ fundingStream: funding.scheme, fundingStreamLang: '' }]
       : [];
 
-    return { titles, kakenUrl: `https://doi.org/10.52926/${awardNumber}`, funderNames, funderDoi, fundingStreams };
+    // プログラム情報識別子: 課題番号からJGN_fundingStreamコードを抽出
+    // JP{alphabetic code}{digits} → {code}（例: JPMJPR2125 → MJPR）
+    const codeMatch = awardNumber.match(/^JP([A-Z]+)\d/i);
+    const fundingStreamId = codeMatch ? codeMatch[1].toUpperCase() : '';
+
+    return { titles, kakenUrl: `https://doi.org/10.52926/${awardNumber}`, funderNames, funderDoi, fundingStreams, fundingStreamId };
   } catch {
     return null;
   }
@@ -286,6 +297,8 @@ async function lookupOne(awardNumber) {
       awardUri: jgnResult.kakenUrl,
       titles: jgnResult.titles,
       fundingStreams: jgnResult.fundingStreams,
+      fundingStreamId: jgnResult.fundingStreamId || '',
+      fundingStreamIdType: jgnResult.fundingStreamId ? 'JGN_fundingStream' : '',
     };
   }
 
@@ -305,7 +318,10 @@ async function lookupOne(awardNumber) {
     };
   }
 
-  return { award: awardNumber, source: null, error: '該当なし（JGN・KAKEN いずれも見つかりません）' };
+  const nistepHint = /^JP[A-Z]/i.test(awardNumber)
+    ? '<a href="https://www.nistep.go.jp/taikei/" target="_blank" class="pv-link">最新の体系的番号一覧（NISTEP）</a>から目視で確認できます。'
+    : '';
+  return { award: awardNumber, source: null, error: '該当なし（JGN・KAKEN いずれも見つかりません）', nistepHint };
 }
 
 // ===== 結果カードを生成 =====
@@ -315,7 +331,8 @@ function buildResultCards(results) {
       return '<div class="result-card error-card">'
         + '<div class="result-card-header">#' + i + ' ' + fmtVal(r.award) + '</div>'
         + '<div class="result-card-body"><table class="pv-table">'
-        + '<tr><td style="color:#c62828">' + fmtVal(r.error) + '</td></tr>'
+        + '<tr><td style="color:#c62828">' + fmtVal(r.error)
+        + (r.nistepHint ? '<br>' + r.nistepHint : '') + '</td></tr>'
         + '</table></div></div>';
     }
     if (r.loading) {
@@ -341,13 +358,17 @@ function buildResultCards(results) {
     let rows = '';
     rows += '<tr><th>助成機関識別子</th><td>' + fmtVal(funderIdUrl) + '</td></tr>';
     rows += '<tr><th>助成機関名</th><td>' + names + '</td></tr>';
-    rows += '<tr><th>プログラム情報識別子</th><td></td></tr>';
+    rows += '<tr><th>プログラム情報識別子</th><td>'
+      + fmtVal(r.fundingStreamId)
+      + (r.fundingStreamIdType ? ' <span style="color:#888">(' + r.fundingStreamIdType + ')</span>' : '')
+      + '</td></tr>';
     const streams = (r.fundingStreams || [])
       .filter(s => s.fundingStream)
       .map(s => fmtVal(s.fundingStream, s.fundingStreamLang))
       .join('<br>');
     rows += '<tr><th>プログラム情報</th><td>' + streams + '</td></tr>';
     rows += '<tr><th>研究課題番号</th><td>' + fmtVal(r.awardNumber) + '</td></tr>';
+    rows += '<tr><th>研究課題番号URI</th><td>' + fmtVal(r.awardUri) + '</td></tr>';
     rows += '<tr><th>研究課題名</th><td>' + titles + '</td></tr>';
 
     return '<div class="result-card">'
@@ -357,14 +378,36 @@ function buildResultCards(results) {
   }).join('');
 }
 
+// ===== 入力モード切替 =====
+function updatePlaceholder() {
+  const mode = document.querySelector('input[name="input-mode"]:checked').value;
+  const ta = document.getElementById('award-input');
+  const label = document.getElementById('input-label');
+  const hint = document.getElementById('input-hint');
+  if (mode === 'ack') {
+    label.textContent = 'Acknowledgementsテキストを貼り付けてください。';
+    ta.placeholder = 'This work was supported by ... (Grant No. JPMJSA1907) ...';
+    hint.textContent = 'テキスト中の JP で始まる課題番号（JP[A-Za-z0-9]+）を自動抽出します。';
+  } else {
+    label.textContent = '課題番号を1行に1つ、改行して入力してください。';
+    ta.placeholder = 'JP21H01234\nJPMJSA1907\n21K12345';
+    hint.textContent = '科研費課題番号（JP付き / なし）や JGN 課題番号を入力できます。';
+  }
+}
+
 // ===== メイン検索処理 =====
 async function doSearch() {
   const input = document.getElementById('award-input').value.trim();
   if (!input) return;
 
-  const numbers = input.split(/\n/)
-    .map(s => s.trim())
-    .filter(Boolean);
+  const mode = document.querySelector('input[name="input-mode"]:checked').value;
+  let numbers;
+  if (mode === 'ack') {
+    // Acknowledgementsテキストから JP で始まる課題番号を抽出（重複排除）
+    numbers = [...new Set(input.match(/JP[A-Za-z0-9]+/g) || [])];
+  } else {
+    numbers = input.split(/\n/).map(s => s.trim()).filter(Boolean);
+  }
 
   if (!numbers.length) return;
 


### PR DESCRIPTION
## Summary

- JGN課題番号からNISTEP体系的番号のプログラムコードを自動抽出し、プログラム情報識別子（`JGN_fundingStream`タイプ）として表示（例: `JPMJPR2125` → `MJPR`）
- Acknowledgementsテキストを貼り付けると `JP[A-Za-z0-9]+` パターンで課題番号を自動抽出して検索するモードを追加
- 結果カードに研究課題番号URIの表示行を追加
- JGN番号で見つからない場合にNISTEP体系的番号一覧へのリンクを表示

## Test plan

- [x] `JPMJPR2125` を検索 → プログラム情報識別子に `MJPR (JGN_fundingStream)` が表示されること
- [x] `JPMJSA1907` を検索 → プログラム情報識別子に `MJSA (JGN_fundingStream)` が表示されること
- [x] `21K12345` を検索 → KAKEN結果、プログラム情報識別子は空欄であること
- [x] Ackモードで論文Acknowledgementsテキストを貼り付け → JP で始まる課題番号が自動抽出・検索されること
- [x] 研究課題番号URIがクリッカブルリンクとして表示されること
- [x] 存在しないJGN番号（例: `JPXXXX9999`）→ エラーカードにNISTEPリンクが表示されること

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)