### PR TITLE
fix: KAKEN XML API 暫定スキップ（CORS非対応による処理時間短縮）

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-05 | KAKEN XML API 暫定スキップ：CORS非対応による処理時間短縮のためfetchKakenXml()呼び出しをコメントアウト（[#59](https://github.com/tzhaya/jc-import-file-maker/issues/59)） |
 | 2026-03-05 | KAKEN XML API CORS対応：fetchKakenXml()にtry/catch追加、CiNii Research OpenSearchを常に最終フォールバックに変更、補助金番号検出時のKAKEN検索リンク表示（[#58](https://github.com/tzhaya/jc-import-file-maker/issues/58)） |
 | 2026-03-04 | KAKEN XML API対応：補助金の研究課題番号から正規の研究課題/領域番号への自動解決、CiNii APIキー未設定時はCiNii Research OpenSearchにフォールバック（[#58](https://github.com/tzhaya/jc-import-file-maker/issues/58)） |
 | 2026-03-03 | 助成情報検索ツール拡張：JGN課題番号からプログラム情報識別子（JGN_fundingStream）を自動設定、Acknowledgementsテキストからの課題番号自動抽出モードを追加（[#56](https://github.com/tzhaya/jc-import-file-maker/issues/56)） |

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-05（KAKEN XML API CORS対応: フォールバック修正・補助金番号KAKEN検索リンク）
+最終更新: 2026-03-05（KAKEN XML API 暫定スキップ: CORS非対応による処理時間短縮）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -9,6 +9,22 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 実装計画: `Implementation_phase1.md`
 対象ファイル: `make_jc_importer.html`（新規作成）
 現在のファイル規模: **約4525行**（STEP 1〜8 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング + ISBN/relation取り込み + JGN連携 + 識別子逆引き + JPCOAR 2.0 語彙対応 + JaLC API対応 + プレビュー機能 + 関連情報取得改善）
+
+---
+
+## 2026-03-05: KAKEN XML API 暫定スキップ — CORS非対応による処理時間短縮（issue #59）
+
+### 背景
+
+KAKEN XML API は CORS 非対応のため、ブラウザから呼び出すと必ずエラーとなりフォールバックに遷移する。無駄なリクエスト・待機時間を削減するため、CORS 解消まで fetchKakenXml() 呼び出しを暫定的にスキップする。
+
+### 実装内容
+
+- `make_jc_importer.html`: buildFunders(), buildJaLCFunders(), renderOneFunder() 内の fetchKakenXml() 呼び出し3箇所をコメントアウト
+- `funder_lookup.html`: lookupOne() 内の fetchKakenXml() 呼び出し1箇所をコメントアウト
+- 全箇所に `// [暫定スキップ]` と `// CORS 解消時は下記コメントを外して有効化すること。` のガイドコメント付与
+- fetchKakenXml() 関数自体は残置（復元容易性のため）
+- 検索順序: JGN → CiNii Research OpenSearch に短縮
 
 ---
 

--- a/funder_lookup.html
+++ b/funder_lookup.html
@@ -334,33 +334,34 @@ function fmtVal(v, lang) {
 async function lookupOne(awardNumber) {
   const hasCiNiiKey = CONFIG.CiNii_API_KEY && CONFIG.CiNii_API_KEY !== 'YOUR_CiNii_API_KEY';
 
-  // KAKEN XML API 優先（CiNii APIキーあり）
-  if (hasCiNiiKey) {
-    const kakenXmlResult = await fetchKakenXml(awardNumber);
-    if (kakenXmlResult) {
-      // 補助金番号の検出
-      let supplementaryWarning = '';
-      const canonicalNumber = kakenXmlResult.normalizedValue || awardNumber;
-      if (kakenXmlResult.normalizedValue) {
-        const inputNorm = /^JP/i.test(awardNumber) ? awardNumber.toUpperCase() : 'JP' + awardNumber.toUpperCase();
-        if (inputNorm !== kakenXmlResult.normalizedValue.toUpperCase()) {
-          supplementaryWarning = `研究課題番号に「補助金の研究課題番号」が入力されたため「研究課題番号」に変更しました（${awardNumber} → ${canonicalNumber}）`;
-        }
-      }
-      return {
-        award: awardNumber,
-        source: 'KAKEN',
-        funderNames: JSPS_FUNDER_NAMES.map(n => ({...n})),
-        funderDoi: JSPS_FUNDER_DOI,
-        funderIdType: 'Crossref Funder',
-        awardNumber: canonicalNumber,
-        awardUri: kakenXmlResult.kakenUrl,
-        titles: kakenXmlResult.titles,
-        fundingStreams: KAKENHI_FUNDING_STREAM,
-        supplementaryWarning,
-      };
-    }
-  }
+  // [暫定スキップ] KAKEN XML API は CORS 非対応のためブラウザから利用不可。
+  // CORS 解消時は下記コメントを外して有効化すること。
+  // if (hasCiNiiKey) {
+  //   const kakenXmlResult = await fetchKakenXml(awardNumber);
+  //   if (kakenXmlResult) {
+  //     // 補助金番号の検出
+  //     let supplementaryWarning = '';
+  //     const canonicalNumber = kakenXmlResult.normalizedValue || awardNumber;
+  //     if (kakenXmlResult.normalizedValue) {
+  //       const inputNorm = /^JP/i.test(awardNumber) ? awardNumber.toUpperCase() : 'JP' + awardNumber.toUpperCase();
+  //       if (inputNorm !== kakenXmlResult.normalizedValue.toUpperCase()) {
+  //         supplementaryWarning = `研究課題番号に「補助金の研究課題番号」が入力されたため「研究課題番号」に変更しました（${awardNumber} → ${canonicalNumber}）`;
+  //       }
+  //     }
+  //     return {
+  //       award: awardNumber,
+  //       source: 'KAKEN',
+  //       funderNames: JSPS_FUNDER_NAMES.map(n => ({...n})),
+  //       funderDoi: JSPS_FUNDER_DOI,
+  //       funderIdType: 'Crossref Funder',
+  //       awardNumber: canonicalNumber,
+  //       awardUri: kakenXmlResult.kakenUrl,
+  //       titles: kakenXmlResult.titles,
+  //       fundingStreams: KAKENHI_FUNDING_STREAM,
+  //       supplementaryWarning,
+  //     };
+  //   }
+  // }
 
   // JGN フォールバック（JP接頭辞あり）
   if (/^JP/i.test(awardNumber)) {

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -1713,14 +1713,15 @@ async function buildFunders(crFunders) {
       const hasCiNiiKey = CONFIG.CiNii_API_KEY && CONFIG.CiNii_API_KEY !== 'YOUR_CiNii_API_KEY';
       let kakenResult = null;
 
-      // KAKEN XML API 優先（CiNii APIキーあり かつ JSPS）
-      if (hasCiNiiKey && isJsps && awardNum) {
-        try {
-          kakenResult = await fetchKakenXml(awardNum);
-        } catch (e) {
-          console.warn(`KAKEN XML取得失敗 (${awardNum}):`, e.message);
-        }
-      }
+      // [暫定スキップ] KAKEN XML API は CORS 非対応のためブラウザから利用不可。
+      // CORS 解消時は下記コメントを外して有効化すること。
+      // if (hasCiNiiKey && isJsps && awardNum) {
+      //   try {
+      //     kakenResult = await fetchKakenXml(awardNum);
+      //   } catch (e) {
+      //     console.warn(`KAKEN XML取得失敗 (${awardNum}):`, e.message);
+      //   }
+      // }
 
       // JGN連携: award が JP で始まる場合（JST助成金等）
       if (!kakenResult && awardNum && /^JP/i.test(awardNum)) {
@@ -1827,12 +1828,13 @@ async function buildJaLCFunders(jalcFundList) {
       const hasCiNiiKey = CONFIG.CiNii_API_KEY && CONFIG.CiNii_API_KEY !== 'YOUR_CiNii_API_KEY';
       let kakenResult = null;
 
-      // KAKEN XML API 優先（CiNii APIキーあり かつ JSPS）
-      if (hasCiNiiKey && isJsps && awardNum) {
-        try { kakenResult = await fetchKakenXml(awardNum); } catch (e) {
-          console.warn(`KAKEN XML取得失敗 (${awardNum}):`, e.message);
-        }
-      }
+      // [暫定スキップ] KAKEN XML API は CORS 非対応のためブラウザから利用不可。
+      // CORS 解消時は下記コメントを外して有効化すること。
+      // if (hasCiNiiKey && isJsps && awardNum) {
+      //   try { kakenResult = await fetchKakenXml(awardNum); } catch (e) {
+      //     console.warn(`KAKEN XML取得失敗 (${awardNum}):`, e.message);
+      //   }
+      // }
 
       // JGN連携: award が JP で始まる場合
       if (!kakenResult && awardNum && /^JP/i.test(awardNum)) {
@@ -3496,18 +3498,19 @@ function renderOneFunder(funder, idx, defLabel) {
       let result = null;
       let supplementaryWarning = '';
 
-      // KAKEN XML API 優先（CiNii APIキーあり）
-      if (hasCiNiiKey) {
-        try { result = await fetchKakenXml(awardNum); } catch { /* ignore */ }
-        // 補助金番号の検出
-        if (result?.normalizedValue) {
-          const inputNorm = /^JP/i.test(awardNum) ? awardNum.toUpperCase() : 'JP' + awardNum.toUpperCase();
-          if (inputNorm !== result.normalizedValue.toUpperCase()) {
-            supplementaryWarning = `研究課題番号に「補助金の研究課題番号」が入力されたため「研究課題番号」に変更しました（${awardNum} → ${result.normalizedValue}）`;
-            if (awardInput) awardInput.value = result.normalizedValue;
-          }
-        }
-      }
+      // [暫定スキップ] KAKEN XML API は CORS 非対応のためブラウザから利用不可。
+      // CORS 解消時は下記コメントを外して有効化すること。
+      // if (hasCiNiiKey) {
+      //   try { result = await fetchKakenXml(awardNum); } catch { /* ignore */ }
+      //   // 補助金番号の検出
+      //   if (result?.normalizedValue) {
+      //     const inputNorm = /^JP/i.test(awardNum) ? awardNum.toUpperCase() : 'JP' + awardNum.toUpperCase();
+      //     if (inputNorm !== result.normalizedValue.toUpperCase()) {
+      //       supplementaryWarning = `研究課題番号に「補助金の研究課題番号」が入力されたため「研究課題番号」に変更しました（${awardNum} → ${result.normalizedValue}）`;
+      //       if (awardInput) awardInput.value = result.normalizedValue;
+      //     }
+      //   }
+      // }
 
       // JGN フォールバック（JP接頭辞あり）
       if (!result && /^JP/i.test(awardNum)) {


### PR DESCRIPTION
## Summary
- KAKEN XML API は CORS 非対応のためブラウザから常にエラーとなり、無駄なリクエスト・待機時間が発生していた
- `fetchKakenXml()` 呼び出し全4箇所をコメントアウトし、検索順序を JGN → CiNii Research OpenSearch に短縮
- 関数自体は残置し `// [暫定スキップ]` コメント付きで、CORS 解消時にコメントを外すだけで復元可能

## 変更箇所
| ファイル | 関数 | 内容 |
|---|---|---|
| `make_jc_importer.html` | `buildFunders()` | Crossrefパスの KAKEN XML 呼び出しをコメントアウト |
| `make_jc_importer.html` | `buildJaLCFunders()` | JaLCパスの KAKEN XML 呼び出しをコメントアウト |
| `make_jc_importer.html` | `renderOneFunder()` | 「助成機関を検索」ボタンの KAKEN XML 呼び出しをコメントアウト |
| `funder_lookup.html` | `lookupOne()` | 課題番号検索の KAKEN XML 呼び出しをコメントアウト |

## Test plan
- [ ] DOI取得時に助成情報がJGN/CiNii経由で正常に取得されることを確認
- [ ] 「助成機関を検索」ボタンがJGN/CiNii経由で正常に動作することを確認
- [ ] `funder_lookup.html` の課題番号検索が正常に動作することを確認
- [ ] KAKEN XML API のタイムアウト待ちが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)