### PR TITLE
feat: OPF参照リンク — ISSNベースのOpen Policy Finder検索リンク追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
   - 要確認項目へのワーニング表示（⚠ 要確認）
   - 参考用の元データ値の表示とURLのリンク
 - OA バッジ表示（Gold / Green / Hybrid / Closed）
+- Open Policy Finder 参照リンク：ISSN付き雑誌論文のDOI取得時に、Open Policy Finderでの雑誌OAポリシー確認リンクを表示
 - JATS XML 形式のDescription(内容記述)からタグの除去
 - Crossref と OpenAlex の著者情報マッチング（姓名一致 → インデックスフォールバック）
 - 空フィールドのみの表示
@@ -142,6 +143,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-05 | OPF参照リンク：ISSNベースのOpen Policy Finder検索リンクをinfo-barに追加。ISSN付き雑誌論文でOAポリシーを別タブで確認可能に（[#62](https://github.com/tzhaya/jc-import-file-maker/issues/62)） |
 | 2026-03-05 | KAKEN XML API 暫定スキップ：CORS非対応による処理時間短縮のためfetchKakenXml()呼び出しをコメントアウト（[#59](https://github.com/tzhaya/jc-import-file-maker/issues/59)） |
 | 2026-03-05 | KAKEN XML API CORS対応：fetchKakenXml()にtry/catch追加、CiNii Research OpenSearchを常に最終フォールバックに変更、補助金番号検出時のKAKEN検索リンク表示（[#58](https://github.com/tzhaya/jc-import-file-maker/issues/58)） |
 | 2026-03-04 | KAKEN XML API対応：補助金の研究課題番号から正規の研究課題/領域番号への自動解決、CiNii APIキー未設定時はCiNii Research OpenSearchにフォールバック（[#58](https://github.com/tzhaya/jc-import-file-maker/issues/58)） |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -21,6 +21,7 @@ make_jc_importer.html
     -   JaLC REST API (`https://api.japanlinkcenter.org/v2/dois/`)
     -   Crossref Works API - JGN（Japan Grant Number）(`https://api.crossref.org/works/10.52926/{award}`)
     -   GitHub API - Commits（更新チェック用）(`https://api.github.com/repos/tzhaya/jc-import-file-maker/commits`)
+    -   Open Policy Finder 検索（参照リンク）(`https://openpolicyfinder.jisc.ac.uk/search?search={ISSN}`)
        
 **メタデータ構造定義**
 - `ItemType.json` ただし、要素から `title_i18n_temp` は除く。 

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-05（KAKEN XML API 暫定スキップ: CORS非対応による処理時間短縮）
+最終更新: 2026-03-05（OPF参照リンク: ISSNベースのOpen Policy Finder検索リンクをinfo-barに追加）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -9,6 +9,32 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 実装計画: `Implementation_phase1.md`
 対象ファイル: `make_jc_importer.html`（新規作成）
 現在のファイル規模: **約4525行**（STEP 1〜8 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング + ISBN/relation取り込み + JGN連携 + 識別子逆引き + JPCOAR 2.0 語彙対応 + JaLC API対応 + プレビュー機能 + 関連情報取得改善）
+
+---
+
+## 2026-03-05: OPF参照リンク — ISSNベースのOpen Policy Finder検索リンク追加（issue #62）
+
+### 背景
+
+Issue #50 で実装予定だった OPF API 連携は CORS 制限により利用できないため、代替として ISSN を元に Open Policy Finder の Web 検索ページへの参照リンクを提供する。
+
+### 実装内容
+
+- `make_jc_importer.html`:
+  - info-bar HTML に `#opf-link-row` を追加（DOI リンク + OA バッジの次行）
+  - 表示テキスト: 「📖 オープンアクセスポリシーをOpen Policy Finderで確認する」
+  - `target="_blank"` + `rel="noopener noreferrer"` で別タブ表示
+  - `fetchCrossrefData()` 内で `mapToItemType()` 完了後に metadata から ISSN を取得し、OPF 検索 URL を生成
+  - ISSN がない場合はリンク非表示
+  - `fetchData()` 内でリセット処理追加
+
+### OPF 検索 URL 仕様
+
+```
+https://openpolicyfinder.jisc.ac.uk/search?search={ISSN}&per_page=10&publication_page=1&publisher_page=1&funder_page=1
+```
+
+- 検索結果が1件のみの場合、OPF サイト側で自動的に雑誌ポリシーページにリダイレクト
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -505,11 +505,15 @@
   </div>
   <div id="loading" style="display:none">⏳ データを取得中です（ROR/ISNIも並行取得）...</div>
   <div id="apikey-warning" style="display:none; background:#fff8e1; border:1px solid #ffe082; color:#6d4c00; padding:8px 12px; border-radius:4px; margin-bottom:8px; font-size:0.9em;">⚠ OpenAlex API Keyが設定されていません。設定しない場合、利用回数が制限されます。</div>
-  <div id="cinii-apikey-warning" style="display:none; background:#fff8e1; border:1px solid #ffe082; color:#6d4c00; padding:8px 12px; border-radius:4px; margin-bottom:8px; font-size:0.9em;">⚠ CiNii APIキーが設定されていません。KAKEN APIによる補助金番号の自動解決は利用できません。</div>
+  <div id="cinii-apikey-warning" style="display:none; background:#fff8e1; border:1px solid #ffe082; color:#6d4c00; padding:8px 12px; border-radius:4px; margin-bottom:8px; font-size:0.9em;">⚠ CiNii APIキーが設定されていません。</div>
   <div id="error-msg"></div>
   <div id="info-bar" style="display:none">
     <a id="doi-link" href="" target="_blank"></a>
     <span id="oa-badge" class="oa-badge"></span>
+    <div id="opf-link-row" style="display:none; width:100%;">
+      <a id="opf-link" href="" target="_blank" rel="noopener noreferrer"
+         style="font-size:0.88em; color:#1565c0;">📖 オープンアクセスポリシーをOpen Policy Finderで確認する</a>
+    </div>
   </div>
 </div>
 
@@ -1426,6 +1430,21 @@ async function fetchCrossrefData(doi) {
 
   // マッピング → レンダリング
   const metadata = await mapToItemType(crJson, oaJson, rorMap);
+
+  // OPF 参照リンク設定
+  const opfRow = document.getElementById('opf-link-row');
+  const opfAnchor = document.getElementById('opf-link');
+  const issns = (metadata.item_30002_source_identifier22 || [])
+    .filter(si => ['ISSN','PISSN','EISSN'].includes(si.subitem_source_identifier_type))
+    .map(si => si.subitem_source_identifier);
+  if (issns.length) {
+    const searchUrl = `https://openpolicyfinder.jisc.ac.uk/search?search=${encodeURIComponent(issns[0])}&per_page=10&publication_page=1&publisher_page=1&funder_page=1`;
+    opfAnchor.href = searchUrl;
+    opfRow.style.display = '';
+  } else {
+    opfRow.style.display = 'none';
+  }
+
   showHints = true;
   renderAll(metadata);
 }
@@ -1458,6 +1477,7 @@ async function fetchData() {
   const doi = normalizeDoi(rawDoi);
 
   document.getElementById('info-bar').style.display = 'none';
+  document.getElementById('opf-link-row').style.display = 'none';
   document.getElementById('preview-area').style.display = 'none';
   const loading = document.getElementById('loading');
   loading.style.display = 'block';


### PR DESCRIPTION
## Summary

- ISSN付き雑誌論文のDOI取得時に、info-barのDOI+OAバッジの次行にOpen Policy Finder検索リンクを表示
- OPF APIがCORS非対応のため、代替としてOPF Web検索ページへのリンクを提供（#62, #44子課題）
- CiNii APIキー未設定時の警告メッセージを簡潔化

## Test plan

- [x] Crossref DOI（ISSN付き雑誌論文）を入力し、「📖 オープンアクセスポリシーをOpen Policy Finderで確認する」リンクが表示されることを確認
- [x] リンクをクリックしてOPFサイトが別タブで開き、雑誌ポリシーページに遷移することを確認
- [x] ISSNのないDOI（書籍等）ではリンクが表示されないことを確認
- [x] CiNii APIキー未設定時の警告が「⚠ CiNii APIキーが設定されていません。」のみ表示されることを確認

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)