### PR TITLE
fix: JaLCデータ取り込み修正（issue #77）

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-11 | JaLCデータ取り込み修正：`keyword_list`を主題（scheme: Other）として取り込み、収録物名のtypeなし時フォールバック追加、出版者をcontent_language優先に並べ替え、出版タイプをVoRデフォルト設定（[#77](https://github.com/tzhaya/jc-import-file-maker/issues/77)） |
 | 2026-03-11 | 「書誌情報」収録誌名の追加・削除UI修正：雑誌名（`bibliographic_titles`）に追加・削除ボタンを追加（[#75](https://github.com/tzhaya/jc-import-file-maker/issues/75)） |
 | 2026-03-10 | Chrome拡張化（[#70](https://github.com/tzhaya/jc-import-file-maker/issues/70)）：Manifest V3 Chrome拡張を追加。Service Worker経由でCORS非対応API（KAKEN XML・JaLC・OPF）を有効化。options.htmlでAPIキーをchrome.storage.localに安全に保存。KAKEN XML API・JaLC APIを本有効化。OPF APIポリシー取得・モーダル表示を実装（[#50](https://github.com/tzhaya/jc-import-file-maker/issues/50)・PR [#61](https://github.com/tzhaya/jc-import-file-maker/pull/61)同時対応） |
 | 2026-03-07 | funder_lookup.html に更新チェック機能を追加：GitHubリポジトリとの最終更新日比較で新バージョンを通知（[#65](https://github.com/tzhaya/jc-import-file-maker/issues/65)） |

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -1939,13 +1939,21 @@ async function mapToItemTypeJaLC(jalcJson) {
     subitem_rights_resource: r.uri || '',
   }));
 
-  // ===== 主題（キーワード）=====
-  const subjects = (jalcJson.subject_list || []).map(s => ({
-    subitem_subject:          s.subject || '',
-    subitem_subject_language: s.lang || '',
-    subitem_subject_scheme:   '',
-    subitem_subject_uri:      '',
-  }));
+  // ===== 主題（subject_list + keyword_list）=====
+  const subjects = [
+    ...(jalcJson.subject_list || []).map(s => ({
+      subitem_subject:          s.subject || '',
+      subitem_subject_language: s.lang || '',
+      subitem_subject_scheme:   '',
+      subitem_subject_uri:      '',
+    })),
+    ...(jalcJson.keyword_list || []).map(k => ({
+      subitem_subject:          k.keyword || '',
+      subitem_subject_language: k.lang || '',
+      subitem_subject_scheme:   'Other',
+      subitem_subject_uri:      '',
+    })),
+  ].filter(s => s.subitem_subject);
   if (!subjects.length) {
     subjects.push({ subitem_subject: '', subitem_subject_language: '', subitem_subject_scheme: '', subitem_subject_uri: '' });
   }
@@ -1974,12 +1982,24 @@ async function mapToItemTypeJaLC(jalcJson) {
   }
 
   // ===== 収録物名（多言語）=====
-  const sourceTitles = (jalcJson.journal_title_name_list || [])
-    .filter(jt => (jt.type || '').toLowerCase() === 'full')
-    .map(jt => ({
-      subitem_source_title: jt.journal_title_name || '',
-      subitem_source_title_language: jt.lang || '',
-    })).filter(st => st.subitem_source_title);
+  // type: full を優先。type がない場合は ja/en の先頭1件ずつをフォールバック取得。
+  // type: abbreviation / before / after は取得しない。
+  const _jtList = jalcJson.journal_title_name_list || [];
+  const _jtFull = _jtList.filter(jt => (jt.type || '').toLowerCase() === 'full');
+  let sourceTitles;
+  if (_jtFull.length) {
+    sourceTitles = _jtFull
+      .map(jt => ({ subitem_source_title: jt.journal_title_name || '', subitem_source_title_language: jt.lang || '' }))
+      .filter(st => st.subitem_source_title);
+  } else {
+    const _jtNoType = _jtList.filter(jt => !jt.type);
+    const _jtJa = _jtNoType.find(jt => jt.lang === 'ja');
+    const _jtEn = _jtNoType.find(jt => jt.lang === 'en');
+    sourceTitles = [_jtJa, _jtEn]
+      .filter(Boolean)
+      .map(jt => ({ subitem_source_title: jt.journal_title_name || '', subitem_source_title_language: jt.lang || '' }))
+      .filter(st => st.subitem_source_title);
+  }
 
   // ===== 内容記述（抄録等）=====
   const descriptions = (jalcJson.description_list || []).filter(d => {
@@ -1991,22 +2011,26 @@ async function mapToItemTypeJaLC(jalcJson) {
     subitem_description_type:     'Abstract',
   }));
 
-  // ===== 出版者（多言語）=====
-  const publishers = (jalcJson.publisher_list || []).map(p => ({
-    subitem_publisher: p.publisher_name || '',
-    subitem_publisher_language: p.lang || '',
-  })).filter(p => p.subitem_publisher);
+  // ===== 言語 (ISO 639-1 → ISO 639-2) =====
+  const LANG_MAP = { 'ja': 'jpn', 'en': 'eng', 'zh': 'zho', 'ko': 'kor', 'fr': 'fra', 'de': 'deu', 'es': 'spa', 'pt': 'por', 'ru': 'rus', 'it': 'ita' };
+  const contentLang = jalcJson.content_language || '';
+  const lang639_2 = LANG_MAP[contentLang] || contentLang;
+
+  // ===== 出版者（多言語、content_language と一致する言語を先頭に）=====
+  const _rawPublishers = (jalcJson.publisher_list || []).filter(p => p.publisher_name);
+  const publishers = (contentLang
+    ? [
+        ..._rawPublishers.filter(p => p.lang === contentLang),
+        ..._rawPublishers.filter(p => p.lang !== contentLang),
+      ]
+    : _rawPublishers
+  ).map(p => ({ subitem_publisher: p.publisher_name, subitem_publisher_language: p.lang || '' }));
 
   // ===== 書誌情報 =====
   const volume    = jalcJson.volume     || '';
   const issue     = jalcJson.issue      || '';
   const firstPage = jalcJson.first_page || '';
   const lastPage  = jalcJson.last_page  || '';
-
-  // ===== 言語 (ISO 639-1 → ISO 639-2) =====
-  const LANG_MAP = { 'ja': 'jpn', 'en': 'eng', 'zh': 'zho', 'ko': 'kor', 'fr': 'fra', 'de': 'deu', 'es': 'spa', 'pt': 'por', 'ru': 'rus', 'it': 'ita' };
-  const contentLang = jalcJson.content_language || '';
-  const lang639_2 = LANG_MAP[contentLang] || contentLang;
 
   // ===== 関連情報 =====
   const relations = [];
@@ -2050,6 +2074,14 @@ async function mapToItemTypeJaLC(jalcJson) {
     }
   });
 
+  // ===== 出版タイプ =====
+  // article_type: 'preprint' → AO、それ以外（'pub' 等）または未設定 → VoR をデフォルト
+  const articleType = (jalcJson.article_type || '').toLowerCase();
+  const versionType     = articleType === 'preprint' ? 'AO'  : 'VoR';
+  const versionResource = articleType === 'preprint'
+    ? VERSION_TYPE_MAP['AO']
+    : VERSION_TYPE_MAP['VoR'];
+
   // ===== メタデータオブジェクト =====
   const metadata = {
     system: {
@@ -2078,7 +2110,7 @@ async function mapToItemTypeJaLC(jalcJson) {
     item_30002_language12: lang639_2 ? [{ subitem_language: lang639_2 }] : [],
     item_30002_resource_type13: { resourcetype, resourceuri },
     item_30002_version14: { subitem_version: '' },
-    item_30002_version_type15: { subitem_version_resource: '', subitem_version_type: '' },
+    item_30002_version_type15: { subitem_version_resource: versionResource, subitem_version_type: versionType },
     item_30002_identifier16: [],
     item_30002_identifier_registration17: { subitem_identifier_reg_text: '', subitem_identifier_reg_type: '' },
     item_30002_relation18: relations,

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -481,6 +481,10 @@
     <tbody>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-11</td>
+        <td style="padding:2px 0;">JaLCデータ取り込み修正：keyword_list→主題取り込み、収録物名type無しフォールバック、出版者言語優先、出版タイプVoRデフォルト設定</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-11</td>
         <td style="padding:2px 0;">書誌情報・収録誌名の追加・削除UI修正：雑誌名に「+ 追加」「×」削除ボタンを追加</td>
       </tr>
       <tr>
@@ -494,10 +498,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-05</td>
         <td style="padding:2px 0;">KAKEN XML API CORS対応：fetchKakenXml()にtry/catch追加、暫定スキップ実装（CORS非対応による処理時間短縮）、CiNii Research OpenSearchを常に最終フォールバックに変更</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-04</td>
-        <td style="padding:2px 0;">KAKEN XML API対応：補助金番号から正規の研究課題番号への自動解決（CiNii APIキー未設定時はCiNii Research OpenSearchにフォールバック）</td>
       </tr>
     </tbody>
   </table>

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-11（書誌情報・収録誌名の追加・削除UI修正: issue #75）
+最終更新: 2026-03-11（JaLCデータ取り込み修正: issue #77）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -9,6 +9,27 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 実装計画: `Implementation_phase1.md`
 対象ファイル: `make_jc_importer.html`（新規作成）
 現在のファイル規模: **約4525行**（STEP 1〜8 + クリーンアップ＋フィールド補完＋参照用列 + APIキー設定 + RA判定 + KAKEN連携 + NCID取得 + DOI必須項目バッジ + Crossref typeマッピング + ISBN/relation取り込み + JGN連携 + 識別子逆引き + JPCOAR 2.0 語彙対応 + JaLC API対応 + プレビュー機能 + 関連情報取得改善）
+
+---
+
+## 2026-03-11: JaLCデータ取り込み修正（issue #77）
+
+### 背景
+
+JaLC APIからのデータ取り込みで以下の問題があった:
+1. `keyword_list` が未参照で主題として取り込まれていなかった
+2. `journal_title_name_list` に `type: full` がない場合、収録物名が空になっていた
+3. `publisher_list` の並び順が固定で、本文言語と一致する出版者名が先頭に来ない場合があった
+4. 出版タイプ（`item_30002_version_type15`）がJaLCパスでは常に空欄になっていた
+
+### 実装内容
+
+`make_jc_importer.html` および `chrome-extension/make_jc_importer.js` の `mapToItemTypeJaLC()` を修正:
+
+1. **主題（`keyword_list`）**: `subject_list`（`subitem_subject_scheme: ''`）に加え、`keyword_list`（`subitem_subject_scheme: 'Other'`）を結合して取り込み
+2. **収録物名フォールバック**: `type: 'full'` エントリが存在する場合はそれを優先。存在しない場合は `type` プロパティ自体がないエントリから `lang: 'ja'` と `lang: 'en'` の先頭1件ずつを取得（`abbreviation` / `before` / `after` は取得しない）
+3. **出版者言語優先**: `content_language` と一致する `lang` の出版者を先頭に並べ替え（言語情報取得ブロックを出版者ブロック前に移動）
+4. **出版タイプデフォルト**: `article_type === 'preprint'` の場合は `AO`、それ以外（`'pub'` 等）または未設定の場合は `VoR` をデフォルト設定
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -472,6 +472,10 @@
     <tbody>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-11</td>
+        <td style="padding:2px 0;">JaLCデータ取り込み修正：keyword_list→主題取り込み、収録物名type無しフォールバック、出版者言語優先、出版タイプVoRデフォルト設定</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-11</td>
         <td style="padding:2px 0;">書誌情報・収録誌名の追加・削除UI修正：雑誌名に「+ 追加」「×」削除ボタンを追加</td>
       </tr>
       <tr>
@@ -485,10 +489,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-05</td>
         <td style="padding:2px 0;">KAKEN XML API CORS対応：fetchKakenXml()にtry/catch追加、暫定スキップ実装（CORS非対応による処理時間短縮）、CiNii Research OpenSearchを常に最終フォールバックに変更</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-04</td>
-        <td style="padding:2px 0;">KAKEN XML API対応：補助金番号から正規の研究課題番号への自動解決（CiNii APIキー未設定時はCiNii Research OpenSearchにフォールバック）</td>
       </tr>
     </tbody>
   </table>
@@ -2512,13 +2512,21 @@ async function mapToItemTypeJaLC(jalcJson) {
     subitem_rights_resource: r.uri || '',
   }));
 
-  // ===== 主題（キーワード）=====
-  const subjects = (jalcJson.subject_list || []).map(s => ({
-    subitem_subject:          s.subject || '',
-    subitem_subject_language: s.lang || '',
-    subitem_subject_scheme:   '',
-    subitem_subject_uri:      '',
-  }));
+  // ===== 主題（subject_list + keyword_list）=====
+  const subjects = [
+    ...(jalcJson.subject_list || []).map(s => ({
+      subitem_subject:          s.subject || '',
+      subitem_subject_language: s.lang || '',
+      subitem_subject_scheme:   '',
+      subitem_subject_uri:      '',
+    })),
+    ...(jalcJson.keyword_list || []).map(k => ({
+      subitem_subject:          k.keyword || '',
+      subitem_subject_language: k.lang || '',
+      subitem_subject_scheme:   'Other',
+      subitem_subject_uri:      '',
+    })),
+  ].filter(s => s.subitem_subject);
   if (!subjects.length) {
     subjects.push({ subitem_subject: '', subitem_subject_language: '', subitem_subject_scheme: '', subitem_subject_uri: '' });
   }
@@ -2547,12 +2555,24 @@ async function mapToItemTypeJaLC(jalcJson) {
   }
 
   // ===== 収録物名（多言語）=====
-  const sourceTitles = (jalcJson.journal_title_name_list || [])
-    .filter(jt => (jt.type || '').toLowerCase() === 'full')
-    .map(jt => ({
-      subitem_source_title: jt.journal_title_name || '',
-      subitem_source_title_language: jt.lang || '',
-    })).filter(st => st.subitem_source_title);
+  // type: full を優先。type がない場合は ja/en の先頭1件ずつをフォールバック取得。
+  // type: abbreviation / before / after は取得しない。
+  const _jtList = jalcJson.journal_title_name_list || [];
+  const _jtFull = _jtList.filter(jt => (jt.type || '').toLowerCase() === 'full');
+  let sourceTitles;
+  if (_jtFull.length) {
+    sourceTitles = _jtFull
+      .map(jt => ({ subitem_source_title: jt.journal_title_name || '', subitem_source_title_language: jt.lang || '' }))
+      .filter(st => st.subitem_source_title);
+  } else {
+    const _jtNoType = _jtList.filter(jt => !jt.type);
+    const _jtJa = _jtNoType.find(jt => jt.lang === 'ja');
+    const _jtEn = _jtNoType.find(jt => jt.lang === 'en');
+    sourceTitles = [_jtJa, _jtEn]
+      .filter(Boolean)
+      .map(jt => ({ subitem_source_title: jt.journal_title_name || '', subitem_source_title_language: jt.lang || '' }))
+      .filter(st => st.subitem_source_title);
+  }
 
   // ===== 内容記述（抄録等）=====
   const descriptions = (jalcJson.description_list || []).filter(d => {
@@ -2564,22 +2584,26 @@ async function mapToItemTypeJaLC(jalcJson) {
     subitem_description_type:     'Abstract',
   }));
 
-  // ===== 出版者（多言語）=====
-  const publishers = (jalcJson.publisher_list || []).map(p => ({
-    subitem_publisher: p.publisher_name || '',
-    subitem_publisher_language: p.lang || '',
-  })).filter(p => p.subitem_publisher);
+  // ===== 言語 (ISO 639-1 → ISO 639-2) =====
+  const LANG_MAP = { 'ja': 'jpn', 'en': 'eng', 'zh': 'zho', 'ko': 'kor', 'fr': 'fra', 'de': 'deu', 'es': 'spa', 'pt': 'por', 'ru': 'rus', 'it': 'ita' };
+  const contentLang = jalcJson.content_language || '';
+  const lang639_2 = LANG_MAP[contentLang] || contentLang;
+
+  // ===== 出版者（多言語、content_language と一致する言語を先頭に）=====
+  const _rawPublishers = (jalcJson.publisher_list || []).filter(p => p.publisher_name);
+  const publishers = (contentLang
+    ? [
+        ..._rawPublishers.filter(p => p.lang === contentLang),
+        ..._rawPublishers.filter(p => p.lang !== contentLang),
+      ]
+    : _rawPublishers
+  ).map(p => ({ subitem_publisher: p.publisher_name, subitem_publisher_language: p.lang || '' }));
 
   // ===== 書誌情報 =====
   const volume    = jalcJson.volume     || '';
   const issue     = jalcJson.issue      || '';
   const firstPage = jalcJson.first_page || '';
   const lastPage  = jalcJson.last_page  || '';
-
-  // ===== 言語 (ISO 639-1 → ISO 639-2) =====
-  const LANG_MAP = { 'ja': 'jpn', 'en': 'eng', 'zh': 'zho', 'ko': 'kor', 'fr': 'fra', 'de': 'deu', 'es': 'spa', 'pt': 'por', 'ru': 'rus', 'it': 'ita' };
-  const contentLang = jalcJson.content_language || '';
-  const lang639_2 = LANG_MAP[contentLang] || contentLang;
 
   // ===== 関連情報 =====
   const relations = [];
@@ -2623,6 +2647,14 @@ async function mapToItemTypeJaLC(jalcJson) {
     }
   });
 
+  // ===== 出版タイプ =====
+  // article_type: 'preprint' → AO、それ以外（'pub' 等）または未設定 → VoR をデフォルト
+  const articleType = (jalcJson.article_type || '').toLowerCase();
+  const versionType     = articleType === 'preprint' ? 'AO'  : 'VoR';
+  const versionResource = articleType === 'preprint'
+    ? VERSION_TYPE_MAP['AO']
+    : VERSION_TYPE_MAP['VoR'];
+
   // ===== メタデータオブジェクト =====
   const metadata = {
     system: {
@@ -2651,7 +2683,7 @@ async function mapToItemTypeJaLC(jalcJson) {
     item_30002_language12: lang639_2 ? [{ subitem_language: lang639_2 }] : [],
     item_30002_resource_type13: { resourcetype, resourceuri },
     item_30002_version14: { subitem_version: '' },
-    item_30002_version_type15: { subitem_version_resource: '', subitem_version_type: '' },
+    item_30002_version_type15: { subitem_version_resource: versionResource, subitem_version_type: versionType },
     item_30002_identifier16: [],
     item_30002_identifier_registration17: { subitem_identifier_reg_text: '', subitem_identifier_reg_type: '' },
     item_30002_relation18: relations,


### PR DESCRIPTION
## Summary

- `keyword_list` を主題（`subitem_subject_scheme: 'Other'`）として取り込み（`subject_list` と結合）
- `journal_title_name_list` の `type: 'full'` エントリが存在しない場合、`type` なしエントリから `lang: 'ja'` / `lang: 'en'` 先頭1件ずつをフォールバック取得（`abbreviation` / `before` / `after` は除外）
- `publisher_list` を `content_language` と一致する言語を先頭に並べ替え
- 出版タイプを `article_type` から判定（`preprint` → `AO`、それ以外または未設定 → `VoR` デフォルト）

Closes #77

## Test plan

- [x] JaLC DOI（例: `10.11408/jjsidre.83.1_3`）で取り込み → `keyword_list` が主題に表示される（scheme: Other）
- [x] `type: full` なし DOI で取り込み → 収録物名が ja/en から取得される
- [x] `content_language: ja` の DOI で取り込み → 出版者の ja エントリが先頭に来る
- [x] `article_type: pub` の DOI で取り込み → 出版タイプが `VoR` に設定される
- [x] `article_type: preprint` の DOI で取り込み → 出版タイプが `AO` に設定される

🤖 Generated with [Claude Code](https://claude.com/claude-code)