### PR TITLE
feat: 言語選択肢に ja-Latn（ローマ字ヨミ）追加 (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Chrome拡張版と通常ブラウザ版の2つの利用方法があります。
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張版 | 2026-03-14 | ver. 1.3.0 | ファイル情報（file35）入力UI追加、主題セクション空データ時の表示修正（[#84](https://github.com/tzhaya/jc-import-file-maker/issues/84)） |
-| インポート用TSV生成ツール | 2026-03-14 | — | ファイル情報（file35）入力UI追加、主題セクション空データ時の表示修正（[#84](https://github.com/tzhaya/jc-import-file-maker/issues/84)） |
+| Chrome拡張版 | 2026-03-14 | ver. 1.3.1 | 言語選択肢に ja-Latn（ローマ字ヨミ）追加（[#28](https://github.com/tzhaya/jc-import-file-maker/issues/28)） |
+| インポート用TSV生成ツール | 2026-03-14 | — | 言語選択肢に ja-Latn（ローマ字ヨミ）追加（[#28](https://github.com/tzhaya/jc-import-file-maker/issues/28)） |
 | 助成情報検索ツール | 2026-03-13 | — | isKakenhi()関数追加（科研費番号パターン判定） |
 
 ## 導入方法
@@ -255,6 +255,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-14 | 言語選択肢に ja-Latn（ローマ字ヨミ）追加：JPCOAR 2.0 スキーマおよび WEKO3 LANGUAGE_VAL2_1 に準拠（[#28](https://github.com/tzhaya/jc-import-file-maker/issues/28)） |
 | 2026-03-14 | ファイル情報（file35）入力UI追加：ファイル選択によるメタデータ自動取得、CCライセンス自動設定、TSV出力・プレビュー対応。主題セクション空データ時の表示修正（[#84](https://github.com/tzhaya/jc-import-file-maker/issues/84)） |
 | 2026-03-13 | 科研費課題番号の識別方法修正：funder DOIに依存せず番号パターン（例: 23KF0079）で科研費を識別、KAKEN/CiNii検索が正しく実行されるよう修正（[#82](https://github.com/tzhaya/jc-import-file-maker/issues/82)） |
 | 2026-03-13 | TSVエクスポート機能追加：TSV_HEADERS_TEMPLATEテンプレート駆動方式によるPhase 2 TSV出力実装、プロパティキープレフィックス自動検出、空フィールド省略、残存issues優先順位整理ドキュメント追加 |

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "DOIからJAIRO Cloud インポート用TSVを生成するツール。CORS非対応APIへのアクセスとAPIキー管理を提供します。",
   "permissions": ["storage", "sidePanel"],
   "host_permissions": [

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -482,6 +482,10 @@
     <tbody>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
+        <td style="padding:2px 0;">言語選択肢に ja-Latn（ローマ字ヨミ）を追加（JPCOAR 2.0 / WEKO3 LANGUAGE_VAL2_1 準拠）</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
         <td style="padding:2px 0;">ファイル情報（file35）入力UI実装：ファイル選択で名前・サイズ・MIME自動取得、権利情報URIからライセンス自動設定、TSV/プレビュー対応</td>
       </tr>
       <tr>
@@ -491,10 +495,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-13</td>
         <td style="padding:2px 0;">TSVエクスポート機能追加：TSV_HEADERS_TEMPLATEテンプレート駆動方式、プロパティキープレフィックス自動検出、空フィールド省略</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-11</td>
-        <td style="padding:2px 0;">OpenSearch検索タブ追加：JAIRO Cloud OpenSearchクライアントをChrome拡張に統合、リポジトリURL設定・資源タイプフィルタ・ページング対応</td>
       </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-11</td>

--- a/docs/future_language_expansion.md
+++ b/docs/future_language_expansion.md
@@ -1,0 +1,38 @@
+# 要対応事項: 言語選択肢の拡張（LANGUAGE_VAL2_2 対応）
+
+作成日: 2026-03-14
+
+## 概要
+
+WEKO3 には言語選択肢として2つのリストが存在する。本ツールは現在、標準リスト（18項目）のみに対応している。
+将来的に拡張リスト（185項目）への対応を検討する必要がある。
+
+## WEKO3 の言語リスト定義
+
+ソース: `RCOSDP/weko` リポジトリ `scripts/demo/properties/property_config.py`
+
+### LANGUAGE_VAL2_1（標準リスト、18項目）— 現在対応済み
+
+```
+ja, ja-Kana, ja-Latn, en, fr, it, de, es, zh-cn, zh-tw, ru, la, ms, eo, ar, el, ko
+```
+
+- 用途: タイトル・内容記述等のテキスト系フィールドの `xml:lang` 属性
+- 本ツールの `TITLE_MAPS.language` はこのリストに準拠
+
+### LANGUAGE_VAL2_2（拡張リスト、185項目）— 未対応
+
+- 全 ISO 639-1 言語コード + `ja-Latn` を含む
+- `ja-Kana` は含まれない
+- WEKO3 の一部プロパティで使用される可能性あり
+
+## 対応方針（案）
+
+- 標準リストで実用上の問題がない間は現状維持
+- 多言語対応が必要なユーザーから要望があれば、拡張リストへの切り替えまたは選択式を検討
+- 対応する場合は `TITLE_MAPS.language` を拡張し、UI のセレクト要素が長大になる点に注意（検索可能なドロップダウン等の UX 改善が必要になる可能性）
+
+## 関連
+
+- Issue #28（`ja-Latn` 追加、対応済み）
+- JPCOAR 2.0 スキーマ: https://schema.irdb.nii.ac.jp/ja/schema/2.0/3-.2

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-14（ファイル情報 file35 入力UI実装 #84）
+最終更新: 2026-03-14（言語選択肢に ja-Latn 追加 #28）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -16,11 +16,27 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.3.1 | 2026-03-14 | 言語選択肢に ja-Latn（ローマ字ヨミ）追加（#28） |
 | 1.3.0 | 2026-03-14 | ファイル情報（file35）入力UI追加（#84）、主題セクション空データ表示修正 |
 | 1.2.1 | 2026-03-13 | 科研費課題番号の識別方法修正（#82）、LOCAL_VERSION同期修正 |
 | 1.2.0 | 2026-03-13 | TSVエクスポート機能追加、残存issues優先順位整理 |
 | 1.1.0 | 2026-03-11 | OpenSearch検索タブ統合、JaLCデータ取込修正、書誌情報UI修正、入力モード自動判定 |
 | 1.0.0 | 2026-03-10 | 初期リリース（Manifest V3、Service Worker、OPFモーダル） |
+
+---
+
+## 2026-03-14: 言語選択肢に ja-Latn 追加（#28）
+
+### 背景
+JPCOAR 2.0 スキーマでは `ja-Kana`（片仮名ヨミ）と `ja-Latn`（ローマ字ヨミ）が別用途の言語コードとして定義されている。本ツールには `ja-Kana` のみ存在し `ja-Latn` が欠けていた。
+
+### 実装内容
+- `TITLE_MAPS.language` 配列に `ja-Latn` を追加（`ja-Kana` の直後、WEKO3 の `LANGUAGE_VAL2_1` と同じ順序）
+- 変更対象: `make_jc_importer.html`、`chrome-extension/make_jc_importer.js`、`make_jc_importer_test.html`
+
+### 補足
+- WEKO3 には185項目の拡張言語リスト（`LANGUAGE_VAL2_2`）も存在する。将来対応の記録を `docs/future_language_expansion.md` に作成
+- `docs/remaining_issues.md` の #28 記述を「置換」から「追加・対応済み」に更新
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -472,6 +472,10 @@
     <tbody>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
+        <td style="padding:2px 0;">言語選択肢に ja-Latn（ローマ字ヨミ）を追加（JPCOAR 2.0 / WEKO3 LANGUAGE_VAL2_1 準拠）</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
         <td style="padding:2px 0;">ファイル情報（file35）入力UI実装：ファイル選択で名前・サイズ・MIME自動取得、権利情報URIからライセンス自動設定、TSV/プレビュー対応</td>
       </tr>
       <tr>
@@ -485,10 +489,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-11</td>
         <td style="padding:2px 0;">JaLCデータ取り込み修正：keyword_list→主題取り込み、収録物名type無しフォールバック、出版者言語優先、出版タイプVoRデフォルト設定</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-11</td>
-        <td style="padding:2px 0;">書誌情報・収録誌名の追加・削除UI修正：雑誌名に「+ 追加」「×」削除ボタンを追加</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
## Summary
- JPCOAR 2.0 スキーマおよび WEKO3 `LANGUAGE_VAL2_1` に準拠し、`TITLE_MAPS.language` に `ja-Latn`（ローマ字ヨミ）を追加
- `ja-Kana`（片仮名ヨミ）と `ja-Latn` は別用途のコードであるため、置換ではなく追加
- WEKO3 拡張言語リスト（`LANGUAGE_VAL2_2`、185項目）への将来対応を `docs/future_language_expansion.md` に記録

## 変更ファイル
- `make_jc_importer.html` — `TITLE_MAPS.language` に `ja-Latn` 追加、更新概要テーブル更新
- `chrome-extension/make_jc_importer.js` — 同上（前回コミットで反映済み）
- `chrome-extension/panel.html` — 更新概要テーブル更新
- `chrome-extension/manifest.json` — `1.3.0` → `1.3.1`
- `docs/future_language_expansion.md` — 新規: 拡張言語リスト要対応事項
- `docs/remaining_issues.md` — #28 を対応済みに更新（前回コミットで反映済み）
- `docs/worklog.md` — 実装記録追記
- `README.md` — 最新の更新・変更履歴追記

## Test plan
- [x] デフォルトDOIでE2Eテスト実施、問題なし
- [x] 言語セレクトに `ja-Latn` が表示されることを確認

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)