### PR TITLE
feat: nameIdentifier スキーム語彙を JPCOAR 2.0 準拠に更新 (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Chrome拡張版と通常ブラウザ版の2つの利用方法があります。
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張版 | 2026-03-14 | ver. 1.3.1 | 言語選択肢に ja-Latn（ローマ字ヨミ）追加（[#28](https://github.com/tzhaya/jc-import-file-maker/issues/28)） |
-| インポート用TSV生成ツール | 2026-03-14 | — | 言語選択肢に ja-Latn（ローマ字ヨミ）追加（[#28](https://github.com/tzhaya/jc-import-file-maker/issues/28)） |
+| Chrome拡張版 | 2026-03-14 | ver. 1.3.2 | 識別子スキーム語彙を JPCOAR 2.0 準拠に更新（e-Rad_Researcher 追加、非推奨スキームを末尾へ）（[#26](https://github.com/tzhaya/jc-import-file-maker/issues/26)） |
+| インポート用TSV生成ツール | 2026-03-14 | — | 識別子スキーム語彙を JPCOAR 2.0 準拠に更新（[#26](https://github.com/tzhaya/jc-import-file-maker/issues/26)） |
 | 助成情報検索ツール | 2026-03-13 | — | isKakenhi()関数追加（科研費番号パターン判定） |
 
 ## 導入方法
@@ -255,6 +255,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-14 | 識別子スキーム語彙を JPCOAR 2.0 準拠に更新：nameIdentifierScheme に e-Rad_Researcher・NRID・kakenhi を追加、affiliationNameIdentifierScheme の非推奨スキーム（GRID・kakenhi）を末尾に移動（[#26](https://github.com/tzhaya/jc-import-file-maker/issues/26)） |
 | 2026-03-14 | 言語選択肢に ja-Latn（ローマ字ヨミ）追加：JPCOAR 2.0 スキーマおよび WEKO3 LANGUAGE_VAL2_1 に準拠（[#28](https://github.com/tzhaya/jc-import-file-maker/issues/28)） |
 | 2026-03-14 | ファイル情報（file35）入力UI追加：ファイル選択によるメタデータ自動取得、CCライセンス自動設定、TSV出力・プレビュー対応。主題セクション空データ時の表示修正（[#84](https://github.com/tzhaya/jc-import-file-maker/issues/84)） |
 | 2026-03-13 | 科研費課題番号の識別方法修正：funder DOIに依存せず番号パターン（例: 23KF0079）で科研費を識別、KAKEN/CiNii検索が正しく実行されるよう修正（[#82](https://github.com/tzhaya/jc-import-file-maker/issues/82)） |

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -456,10 +456,10 @@ const TITLE_MAPS = {
     'HostingInstitution','Producer','ProjectLeader','ProjectManager','ProjectMember',
     'RelatedPerson','Researcher','ResearchGroup','Sponsor','Supervisor','WorkPackageLeader','Other'
   ],
-  // 所属機関識別子スキーム
-  affiliationNameIdentifierScheme: ['ISNI','ROR','GRID','kakenhi','Ringgold'],
-  // 識別子タイプ（作成者/寄与者）
-  nameIdentifierScheme: ['ORCID','CiNii','ISNI','J-GLOBAL'],
+  // 所属機関識別子スキーム（JPCOAR 2.0: GRID・kakenhi は非推奨のため末尾）
+  affiliationNameIdentifierScheme: ['ISNI','ROR','Ringgold','GRID','kakenhi'],
+  // 識別子タイプ（作成者/寄与者）（JPCOAR 2.0: e-Rad_Researcher 追加、NRID・kakenhi は非推奨のため末尾）
+  nameIdentifierScheme: ['ORCID','CiNii','ISNI','J-GLOBAL','e-Rad_Researcher','NRID','kakenhi'],
   // 識別子タイプ（作成者姓名タイプ）
   creatorNameType: ['Personal','Organizational'],
   // 識別子タイプ（識別子フィールド）
@@ -1372,7 +1372,7 @@ function buildJaLCAuthors(jalcCreators) {
         });
       } else if (idType === 'ERAD' || idType === 'E-RAD') {
         if (rid.id_code) nameIdentifiers.push({
-          nameIdentifier: rid.id_code, nameIdentifierScheme: 'e-Rad',
+          nameIdentifier: rid.id_code, nameIdentifierScheme: 'e-Rad_Researcher',
           nameIdentifierURI: `https://kaken.nii.ac.jp/search/?qe=${rid.id_code}`,
         });
       }

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "DOIからJAIRO Cloud インポート用TSVを生成するツール。CORS非対応APIへのアクセスとAPIキー管理を提供します。",
   "permissions": ["storage", "sidePanel"],
   "host_permissions": [

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -482,6 +482,10 @@
     <tbody>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
+        <td style="padding:2px 0;">識別子スキーム語彙を JPCOAR 2.0 準拠に更新：nameIdentifierScheme に e-Rad_Researcher を追加、非推奨スキーム（NRID・GRID・kakenhi）を末尾に移動</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
         <td style="padding:2px 0;">言語選択肢に ja-Latn（ローマ字ヨミ）を追加（JPCOAR 2.0 / WEKO3 LANGUAGE_VAL2_1 準拠）</td>
       </tr>
       <tr>
@@ -495,10 +499,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-13</td>
         <td style="padding:2px 0;">TSVエクスポート機能追加：TSV_HEADERS_TEMPLATEテンプレート駆動方式、プロパティキープレフィックス自動検出、空フィールド省略</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-11</td>
-        <td style="padding:2px 0;">JaLCデータ取り込み修正：keyword_list→主題取り込み、収録物名type無しフォールバック、出版者言語優先、出版タイプVoRデフォルト設定</td>
       </tr>
     </tbody>
   </table>

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-14（言語選択肢に ja-Latn 追加 #28）
+最終更新: 2026-03-14（nameIdentifier スキーム語彙 JPCOAR 2.0 対応 #26）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -16,12 +16,32 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.3.2 | 2026-03-14 | 識別子スキーム語彙 JPCOAR 2.0 対応（#26） |
 | 1.3.1 | 2026-03-14 | 言語選択肢に ja-Latn（ローマ字ヨミ）追加（#28） |
 | 1.3.0 | 2026-03-14 | ファイル情報（file35）入力UI追加（#84）、主題セクション空データ表示修正 |
 | 1.2.1 | 2026-03-13 | 科研費課題番号の識別方法修正（#82）、LOCAL_VERSION同期修正 |
 | 1.2.0 | 2026-03-13 | TSVエクスポート機能追加、残存issues優先順位整理 |
 | 1.1.0 | 2026-03-11 | OpenSearch検索タブ統合、JaLCデータ取込修正、書誌情報UI修正、入力モード自動判定 |
 | 1.0.0 | 2026-03-10 | 初期リリース（Manifest V3、Service Worker、OPFモーダル） |
+
+---
+
+## 2026-03-14: nameIdentifier スキーム語彙 JPCOAR 2.0 対応（#26）
+
+### 背景
+
+JPCOAR スキーマ 2.0 では nameIdentifier（人物識別子）と affiliationNameIdentifier（所属機関識別子）の許容スキームが改訂された。旧来の `TITLE_MAPS` には `e-Rad_Researcher` が欠落しており、また `buildJaLCAuthors()` が `'e-Rad'`（旧称）をハードコードしていた。
+
+### 変更内容
+
+- `TITLE_MAPS.nameIdentifierScheme`: `['ORCID','CiNii','ISNI','J-GLOBAL']` → `['ORCID','CiNii','ISNI','J-GLOBAL','e-Rad_Researcher','NRID','kakenhi']`
+  - JPCOAR 2.0 で新たに有効な `e-Rad_Researcher` を追加
+  - 非推奨の `NRID`・`kakenhi` は既存データ互換性のため末尾に残す
+- `TITLE_MAPS.affiliationNameIdentifierScheme`: `['ISNI','ROR','GRID','kakenhi','Ringgold']` → `['ISNI','ROR','Ringgold','GRID','kakenhi']`
+  - 非推奨の `GRID`・`kakenhi` を末尾に移動
+- `buildJaLCAuthors()`: `nameIdentifierScheme: 'e-Rad'` → `'e-Rad_Researcher'`
+- `chrome-extension/make_jc_importer.js` に同じ変更を反映
+- `manifest.json` version: 1.3.1 → 1.3.2（patch up）
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -472,6 +472,10 @@
     <tbody>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
+        <td style="padding:2px 0;">識別子スキーム語彙を JPCOAR 2.0 準拠に更新：nameIdentifierScheme に e-Rad_Researcher を追加、非推奨スキーム（NRID・GRID・kakenhi）を末尾に移動</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
         <td style="padding:2px 0;">言語選択肢に ja-Latn（ローマ字ヨミ）を追加（JPCOAR 2.0 / WEKO3 LANGUAGE_VAL2_1 準拠）</td>
       </tr>
       <tr>
@@ -485,10 +489,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-13</td>
         <td style="padding:2px 0;">TSVエクスポート機能追加：TSV_HEADERS_TEMPLATEテンプレート駆動方式、プロパティキープレフィックス自動検出、空フィールド省略</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-11</td>
-        <td style="padding:2px 0;">JaLCデータ取り込み修正：keyword_list→主題取り込み、収録物名type無しフォールバック、出版者言語優先、出版タイプVoRデフォルト設定</td>
       </tr>
     </tbody>
   </table>
@@ -1041,10 +1041,10 @@ const TITLE_MAPS = {
     'HostingInstitution','Producer','ProjectLeader','ProjectManager','ProjectMember',
     'RelatedPerson','Researcher','ResearchGroup','Sponsor','Supervisor','WorkPackageLeader','Other'
   ],
-  // 所属機関識別子スキーム
-  affiliationNameIdentifierScheme: ['ISNI','ROR','GRID','kakenhi','Ringgold'],
-  // 識別子タイプ（作成者/寄与者）
-  nameIdentifierScheme: ['ORCID','CiNii','ISNI','J-GLOBAL'],
+  // 所属機関識別子スキーム（JPCOAR 2.0: GRID・kakenhi は非推奨のため末尾）
+  affiliationNameIdentifierScheme: ['ISNI','ROR','Ringgold','GRID','kakenhi'],
+  // 識別子タイプ（作成者/寄与者）（JPCOAR 2.0: e-Rad_Researcher 追加、NRID・kakenhi は非推奨のため末尾）
+  nameIdentifierScheme: ['ORCID','CiNii','ISNI','J-GLOBAL','e-Rad_Researcher','NRID','kakenhi'],
   // 識別子タイプ（作成者姓名タイプ）
   creatorNameType: ['Personal','Organizational'],
   // 識別子タイプ（識別子フィールド）
@@ -1957,7 +1957,7 @@ function buildJaLCAuthors(jalcCreators) {
         });
       } else if (idType === 'ERAD' || idType === 'E-RAD') {
         if (rid.id_code) nameIdentifiers.push({
-          nameIdentifier: rid.id_code, nameIdentifierScheme: 'e-Rad',
+          nameIdentifier: rid.id_code, nameIdentifierScheme: 'e-Rad_Researcher',
           nameIdentifierURI: `https://kaken.nii.ac.jp/search/?qe=${rid.id_code}`,
         });
       }


### PR DESCRIPTION
## Summary

- `TITLE_MAPS.nameIdentifierScheme` に `e-Rad_Researcher`・`NRID`・`kakenhi` を追加（非推奨は末尾配置）
- `TITLE_MAPS.affiliationNameIdentifierScheme` の非推奨スキーム（`GRID`・`kakenhi`）を末尾に移動
- `buildJaLCAuthors()` のハードコードされた `'e-Rad'` を `'e-Rad_Researcher'` に修正
- `chrome-extension/make_jc_importer.js` に同じ変更を反映
- `manifest.json`: 1.3.1 → 1.3.2

Closes #26

## Test plan

- [x] 作成者/寄与者の「識別子追加」で Scheme セレクトに `e-Rad_Researcher`・`NRID`・`kakenhi` が表示されることを確認
- [x] 所属機関識別子の Scheme セレクトで `Ringgold` が上位に、`GRID`・`kakenhi` が末尾に表示されることを確認
- [x] JaLC e-Rad ID を持つ論文でプレビューのスキームが `e-Rad_Researcher` になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)