### PR TITLE
feat: 作成者タイプ（creatorType）の初期値を空値に変更 (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Chrome拡張版と通常ブラウザ版の2つの利用方法があります。
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張版 | 2026-03-14 | ver. 1.3.2 | 識別子スキーム語彙を JPCOAR 2.0 準拠に更新（e-Rad_Researcher 追加、非推奨スキームを末尾へ）（[#26](https://github.com/tzhaya/jc-import-file-maker/issues/26)） |
-| インポート用TSV生成ツール | 2026-03-14 | — | 識別子スキーム語彙を JPCOAR 2.0 準拠に更新（[#26](https://github.com/tzhaya/jc-import-file-maker/issues/26)） |
+| Chrome拡張版 | 2026-03-14 | ver. 1.3.3 | 作成者タイプ（creatorType）初期値を空値に変更（JPCOAR 2.0 準拠）（[#27](https://github.com/tzhaya/jc-import-file-maker/issues/27)） |
+| インポート用TSV生成ツール | 2026-03-14 | — | 作成者タイプ（creatorType）初期値を空値に変更（JPCOAR 2.0 準拠）（[#27](https://github.com/tzhaya/jc-import-file-maker/issues/27)） |
 | 助成情報検索ツール | 2026-03-13 | — | isKakenhi()関数追加（科研費番号パターン判定） |
 
 ## 導入方法
@@ -255,6 +255,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-14 | 作成者タイプ（creatorType）の初期値を空値に変更（JPCOAR 2.0 では自由テキスト定義のため、API取得時も空値とする）（[#27](https://github.com/tzhaya/jc-import-file-maker/issues/27)） |
 | 2026-03-14 | 識別子スキーム語彙を JPCOAR 2.0 準拠に更新：nameIdentifierScheme に e-Rad_Researcher・NRID・kakenhi を追加、affiliationNameIdentifierScheme の非推奨スキーム（GRID・kakenhi）を末尾に移動（[#26](https://github.com/tzhaya/jc-import-file-maker/issues/26)） |
 | 2026-03-14 | 言語選択肢に ja-Latn（ローマ字ヨミ）追加：JPCOAR 2.0 スキーマおよび WEKO3 LANGUAGE_VAL2_1 に準拠（[#28](https://github.com/tzhaya/jc-import-file-maker/issues/28)） |
 | 2026-03-14 | ファイル情報（file35）入力UI追加：ファイル選択によるメタデータ自動取得、CCライセンス自動設定、TSV出力・プレビュー対応。主題セクション空データ時の表示修正（[#84](https://github.com/tzhaya/jc-import-file-maker/issues/84)） |

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -1331,7 +1331,7 @@ function buildAuthors(crAuthors, oaAuthorships, rorMap) {
       : [];
 
     return {
-      creatorType: 'Author',
+      creatorType: '',
       creatorNames: [{ creatorName: fullName, creatorNameLang: 'en', creatorNameType: 'Personal', _warnLang: true }],
       familyNames:  family ? [{ familyName: family, familyNameLang: 'en', _warnLang: true }] : [],
       givenNames:   given  ? [{ givenName:  given,  givenNameLang:  'en', _warnLang: true }] : [],
@@ -1416,7 +1416,7 @@ function buildJaLCAuthors(jalcCreators) {
     });
 
     return {
-      creatorType: 'Author',
+      creatorType: '',
       creatorNames,
       familyNames,
       givenNames,

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "DOIからJAIRO Cloud インポート用TSVを生成するツール。CORS非対応APIへのアクセスとAPIキー管理を提供します。",
   "permissions": ["storage", "sidePanel"],
   "host_permissions": [

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -482,6 +482,10 @@
     <tbody>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
+        <td style="padding:2px 0;">作成者タイプ（creatorType）の初期値を空値に変更（JPCOAR 2.0 準拠、自由テキスト入力）</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
         <td style="padding:2px 0;">識別子スキーム語彙を JPCOAR 2.0 準拠に更新：nameIdentifierScheme に e-Rad_Researcher を追加、非推奨スキーム（NRID・GRID・kakenhi）を末尾に移動</td>
       </tr>
       <tr>
@@ -495,10 +499,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-13</td>
         <td style="padding:2px 0;">科研費課題番号の識別方法修正：funder DOIに依存せず番号パターン（例: 23KF0079）で科研費を識別、KAKEN/CiNii検索が正しく実行されるよう修正</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-13</td>
-        <td style="padding:2px 0;">TSVエクスポート機能追加：TSV_HEADERS_TEMPLATEテンプレート駆動方式、プロパティキープレフィックス自動検出、空フィールド省略</td>
       </tr>
     </tbody>
   </table>

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-14（nameIdentifier スキーム語彙 JPCOAR 2.0 対応 #26）
+最終更新: 2026-03-14（作成者タイプ creatorType 初期値を空値に変更 #27）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -16,6 +16,7 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.3.3 | 2026-03-14 | 作成者タイプ creatorType 初期値を空値に変更（#27） |
 | 1.3.2 | 2026-03-14 | 識別子スキーム語彙 JPCOAR 2.0 対応（#26） |
 | 1.3.1 | 2026-03-14 | 言語選択肢に ja-Latn（ローマ字ヨミ）追加（#28） |
 | 1.3.0 | 2026-03-14 | ファイル情報（file35）入力UI追加（#84）、主題セクション空データ表示修正 |
@@ -23,6 +24,20 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 | 1.2.0 | 2026-03-13 | TSVエクスポート機能追加、残存issues優先順位整理 |
 | 1.1.0 | 2026-03-11 | OpenSearch検索タブ統合、JaLCデータ取込修正、書誌情報UI修正、入力モード自動判定 |
 | 1.0.0 | 2026-03-10 | 初期リリース（Manifest V3、Service Worker、OPFモーダル） |
+
+---
+
+## 2026-03-14: 作成者タイプ creatorType 初期値を空値に変更（#27）
+
+### 変更内容
+JPCOAR 2.0 スキーマで `jpcoar:creator` の `creatorType` 属性は自由テキスト（統制語彙なし）と定義されているため、API取得時の初期値を `'Author'` から `''`（空値）に変更。ユーザーが必要に応じて任意の値を入力できるようにした。UIはテキスト入力のまま維持。
+
+### 変更箇所
+- `make_jc_importer.html` `buildAuthors()`: `creatorType: 'Author'` → `creatorType: ''`
+- `make_jc_importer.html` `buildJaLCAuthors()`: `creatorType: 'Author'` → `creatorType: ''`
+- `chrome-extension/make_jc_importer.js`: 同上2箇所を同期
+- `chrome-extension/panel.html`: 更新概要テーブルに追記
+- `chrome-extension/manifest.json`: 1.3.2 → 1.3.3
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -472,6 +472,10 @@
     <tbody>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
+        <td style="padding:2px 0;">作成者タイプ（creatorType）の初期値を空値に変更（JPCOAR 2.0 準拠、自由テキスト入力）</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
         <td style="padding:2px 0;">識別子スキーム語彙を JPCOAR 2.0 準拠に更新：nameIdentifierScheme に e-Rad_Researcher を追加、非推奨スキーム（NRID・GRID・kakenhi）を末尾に移動</td>
       </tr>
       <tr>
@@ -485,10 +489,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-13</td>
         <td style="padding:2px 0;">科研費課題番号の識別方法修正：funder DOIに依存せず番号パターン（例: 23KF0079）で科研費を識別、KAKEN/CiNii検索が正しく実行されるよう修正</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-13</td>
-        <td style="padding:2px 0;">TSVエクスポート機能追加：TSV_HEADERS_TEMPLATEテンプレート駆動方式、プロパティキープレフィックス自動検出、空フィールド省略</td>
       </tr>
     </tbody>
   </table>
@@ -1916,7 +1916,7 @@ function buildAuthors(crAuthors, oaAuthorships, rorMap) {
       : [];
 
     return {
-      creatorType: 'Author',
+      creatorType: '',
       creatorNames: [{ creatorName: fullName, creatorNameLang: 'en', creatorNameType: 'Personal', _warnLang: true }],
       familyNames:  family ? [{ familyName: family, familyNameLang: 'en', _warnLang: true }] : [],
       givenNames:   given  ? [{ givenName:  given,  givenNameLang:  'en', _warnLang: true }] : [],
@@ -2001,7 +2001,7 @@ function buildJaLCAuthors(jalcCreators) {
     });
 
     return {
-      creatorType: 'Author',
+      creatorType: '',
       creatorNames,
       familyNames,
       givenNames,


### PR DESCRIPTION
## 概要

JPCOAR 2.0 スキーマで `jpcoar:creator` の `creatorType` 属性は自由テキスト（統制語彙なし）と定義されているため、API取得時にハードコードしていた `'Author'` を空値 `''` に変更。

## 変更内容

- `buildAuthors()`: `creatorType: 'Author'` → `creatorType: ''`
- `buildJaLCAuthors()`: `creatorType: 'Author'` → `creatorType: ''`
- `chrome-extension/make_jc_importer.js`: 同上2箇所を同期
- `chrome-extension/manifest.json`: `1.3.2` → `1.3.3`

## 背景

JPCOAR 2.0 スキーマ（https://schema.irdb.nii.ac.jp/ja/schema/2.0/3）では `creatorType` は「コンテンツの作成に直接的に関りを持つものの役割を簡潔に記入する」自由テキストであり、スキーマ例示値も「著」（日本語）。ユーザーが必要に応じて任意の値を入力できるよう、初期値を空値とした。

## テスト計画

- [x] E2E テスト PASSED（DOI: `10.1038/s41467-023-40773-1`）
- [x] funder テスト PASSED（`JP16K07412`）

## 関連

Closes #27

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)