### PR TITLE
fix: 助成情報プログラム情報の表示順序修正・ドキュメント補完（#34）

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Chrome拡張版と通常ブラウザ版の2つの利用方法があります。
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張版 | 2026-03-15 | ver. 1.3.4 | 助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0）（[#34](https://github.com/tzhaya/jc-import-file-maker/issues/34)） |
-| インポート用TSV生成ツール | 2026-03-15 | — | 助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0）（[#34](https://github.com/tzhaya/jc-import-file-maker/issues/34)） |
+| Chrome拡張版 | 2026-03-15 | ver. 1.3.5 | 助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0）、表示順序修正（[#34](https://github.com/tzhaya/jc-import-file-maker/issues/34)） |
+| インポート用TSV生成ツール | 2026-03-15 | — | 助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0）、表示順序修正（[#34](https://github.com/tzhaya/jc-import-file-maker/issues/34)） |
 | 助成情報検索ツール | 2026-03-13 | — | isKakenhi()関数追加（科研費番号パターン判定） |
 
 ## 導入方法
@@ -256,6 +256,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-15 | 助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0 fundingStream / fundingStreamIdentifier）：JGN APIからプログラム情報を自動取得、KAKENHI課題には固定値を自動設定、表示順序を助成機関→プログラム情報→研究課題番号に修正（[#34](https://github.com/tzhaya/jc-import-file-maker/issues/34)） |
 | 2026-03-14 | 作成者タイプ（creatorType）の初期値を空値に変更（JPCOAR 2.0 では自由テキスト定義のため、API取得時も空値とする）（[#27](https://github.com/tzhaya/jc-import-file-maker/issues/27)） |
 | 2026-03-14 | 識別子スキーム語彙を JPCOAR 2.0 準拠に更新：nameIdentifierScheme に e-Rad_Researcher・NRID・kakenhi を追加、affiliationNameIdentifierScheme の非推奨スキーム（GRID・kakenhi）を末尾に移動（[#26](https://github.com/tzhaya/jc-import-file-maker/issues/26)） |
 | 2026-03-14 | 言語選択肢に ja-Latn（ローマ字ヨミ）追加：JPCOAR 2.0 スキーマおよび WEKO3 LANGUAGE_VAL2_1 に準拠（[#28](https://github.com/tzhaya/jc-import-file-maker/issues/28)） |

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -3308,6 +3308,32 @@ function renderOneFunder(funder, idx, defLabel) {
   });
   updateFunderLookup = updateFV;
 
+  // プログラム情報識別子（JPCOAR 2.0 fundingStreamIdentifier）
+  const fsId = funder.subitem_funding_stream_identifiers || {};
+  fundContent.appendChild(createFieldRow('プログラム情報識別子', fsId.subitem_funding_stream_identifier || '', 'text', null,
+    { fieldKey: 'subitem_funding_stream_identifier' }));
+  fundContent.appendChild(createFieldRow('識別子タイプ', fsId.subitem_funding_stream_identifier_type || '', 'select',
+    'subitem_funding_stream_identifier_type', { fieldKey: 'subitem_funding_stream_identifier_type' }));
+  fundContent.appendChild(createFieldRow('識別子タイプURI', fsId.subitem_funding_stream_identifier_type_uri || '', 'text', null,
+    { fieldKey: 'subitem_funding_stream_identifier_type_uri' }));
+
+  // プログラム情報（JPCOAR 2.0 fundingStream、配列）
+  const { wrapper: fsWrap, content: fsCont } = createNestedSectionHeader('プログラム情報', 2, (cont) => {
+    const { grp, delBtn } = createEntryGroup();
+    grp.appendChild(createFieldRow('プログラム情報', '', 'text', null, { fieldKey: 'subitem_funding_stream' }));
+    grp.appendChild(createFieldRow('言語', '', 'select', 'language', { fieldKey: 'subitem_funding_stream_language' }));
+    grp.appendChild(delBtn);
+    cont.appendChild(grp);
+  });
+  (funder.subitem_funding_streams || []).forEach(fs => {
+    const { grp, delBtn } = createEntryGroup();
+    grp.appendChild(createFieldRow('プログラム情報', fs.subitem_funding_stream || '', 'text', null, { fieldKey: 'subitem_funding_stream' }));
+    grp.appendChild(createFieldRow('言語', fs.subitem_funding_stream_language || '', 'select', 'language', { fieldKey: 'subitem_funding_stream_language' }));
+    grp.appendChild(delBtn);
+    fsCont.appendChild(grp);
+  });
+  fundContent.appendChild(fsWrap);
+
   // 研究課題番号（fieldset）+ 助成機関を検索ボタン
   const aw = funder.subitem_award_numbers || {};
   const awardRow = createFieldRow('研究課題番号', aw.subitem_award_number || '', 'text', null, { fieldKey: 'subitem_award_number' });
@@ -3341,32 +3367,6 @@ function renderOneFunder(funder, idx, defLabel) {
     atCont.appendChild(grp);
   });
   fundContent.appendChild(atWrap);
-
-  // プログラム情報識別子（JPCOAR 2.0 fundingStreamIdentifier）
-  const fsId = funder.subitem_funding_stream_identifiers || {};
-  fundContent.appendChild(createFieldRow('プログラム情報識別子', fsId.subitem_funding_stream_identifier || '', 'text', null,
-    { fieldKey: 'subitem_funding_stream_identifier' }));
-  fundContent.appendChild(createFieldRow('識別子タイプ', fsId.subitem_funding_stream_identifier_type || '', 'select',
-    'subitem_funding_stream_identifier_type', { fieldKey: 'subitem_funding_stream_identifier_type' }));
-  fundContent.appendChild(createFieldRow('識別子タイプURI', fsId.subitem_funding_stream_identifier_type_uri || '', 'text', null,
-    { fieldKey: 'subitem_funding_stream_identifier_type_uri' }));
-
-  // プログラム情報（JPCOAR 2.0 fundingStream、配列）
-  const { wrapper: fsWrap, content: fsCont } = createNestedSectionHeader('プログラム情報', 2, (cont) => {
-    const { grp, delBtn } = createEntryGroup();
-    grp.appendChild(createFieldRow('プログラム情報', '', 'text', null, { fieldKey: 'subitem_funding_stream' }));
-    grp.appendChild(createFieldRow('言語', '', 'select', 'language', { fieldKey: 'subitem_funding_stream_language' }));
-    grp.appendChild(delBtn);
-    cont.appendChild(grp);
-  });
-  (funder.subitem_funding_streams || []).forEach(fs => {
-    const { grp, delBtn } = createEntryGroup();
-    grp.appendChild(createFieldRow('プログラム情報', fs.subitem_funding_stream || '', 'text', null, { fieldKey: 'subitem_funding_stream' }));
-    grp.appendChild(createFieldRow('言語', fs.subitem_funding_stream_language || '', 'select', 'language', { fieldKey: 'subitem_funding_stream_language' }));
-    grp.appendChild(delBtn);
-    fsCont.appendChild(grp);
-  });
-  fundContent.appendChild(fsWrap);
 
   // 助成機関を検索ボタンの結果表示エリアとイベントハンドラ
   const awardResultEl = document.createElement('div');
@@ -4881,7 +4881,7 @@ function buildFundingPreview(funders) {
   if (!nonEmpty.length) return '';
 
   let html = '<table class="pv-inner-table"><thead><tr>';
-  html += '<th>#</th><th>\u52A9\u6210\u6A5F\u95A2\u540D</th><th>\u8B58\u5225\u5B50</th><th>\u8AB2\u984C\u756A\u53F7</th><th>\u8AB2\u984C\u540D</th><th>\u30D7\u30ED\u30B0\u30E9\u30E0\u60C5\u5831</th>';
+  html += '<th>#</th><th>\u52A9\u6210\u6A5F\u95A2\u540D</th><th>\u8B58\u5225\u5B50</th><th>\u30D7\u30ED\u30B0\u30E9\u30E0\u60C5\u5831</th><th>\u8AB2\u984C\u756A\u53F7</th><th>\u8AB2\u984C\u540D</th>';
   html += '</tr></thead><tbody>';
 
   nonEmpty.forEach((f, i) => {
@@ -4891,12 +4891,6 @@ function buildFundingPreview(funders) {
     const idStr = fId.subitem_funder_identifier
       ? (fId.subitem_funder_identifier_type ? fId.subitem_funder_identifier_type + ': ' : '') + fmtVal(fId.subitem_funder_identifier)
       : '';
-    const aw = f.subitem_award_numbers || {};
-    const awardStr = aw.subitem_award_number
-      ? fmtVal(aw.subitem_award_number) + (aw.subitem_award_uri ? ' (' + fmtVal(aw.subitem_award_uri) + ')' : '')
-      : '';
-    const titles = (f.subitem_award_titles || []).filter(t => t.subitem_award_title)
-      .map(t => fmtVal(t.subitem_award_title, t.subitem_award_title_language)).join('<br>');
     // プログラム情報
     const streams = (f.subitem_funding_streams || []).filter(s => s.subitem_funding_stream)
       .map(s => fmtVal(s.subitem_funding_stream, s.subitem_funding_stream_language)).join('<br>');
@@ -4905,7 +4899,13 @@ function buildFundingPreview(funders) {
       ? (fsIdObj.subitem_funding_stream_identifier_type ? fsIdObj.subitem_funding_stream_identifier_type + ': ' : '') + fmtVal(fsIdObj.subitem_funding_stream_identifier)
       : '';
     const streamCol = [fsIdStr, streams].filter(Boolean).join('<br>');
-    html += '<tr><td>' + i + '</td><td>' + names + '</td><td>' + idStr + '</td><td>' + awardStr + '</td><td>' + titles + '</td><td>' + streamCol + '</td></tr>';
+    const aw = f.subitem_award_numbers || {};
+    const awardStr = aw.subitem_award_number
+      ? fmtVal(aw.subitem_award_number) + (aw.subitem_award_uri ? ' (' + fmtVal(aw.subitem_award_uri) + ')' : '')
+      : '';
+    const titles = (f.subitem_award_titles || []).filter(t => t.subitem_award_title)
+      .map(t => fmtVal(t.subitem_award_title, t.subitem_award_title_language)).join('<br>');
+    html += '<tr><td>' + i + '</td><td>' + names + '</td><td>' + idStr + '</td><td>' + streamCol + '</td><td>' + awardStr + '</td><td>' + titles + '</td></tr>';
   });
   html += '</tbody></table>';
   return html;
@@ -5122,7 +5122,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-03-14';
+  const LOCAL_VERSION = '2026-03-15';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "DOIからJAIRO Cloud インポート用TSVを生成するツール。CORS非対応APIへのアクセスとAPIキー管理を提供します。",
   "permissions": ["storage", "sidePanel"],
   "host_permissions": [

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -468,7 +468,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-03-14 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-03-15 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -480,6 +480,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-15</td>
+        <td style="padding:2px 0;">助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0）、表示順序を助成機関→プログラム情報→研究課題番号に修正</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
         <td style="padding:2px 0;">作成者タイプ（creatorType）の初期値を空値に変更（JPCOAR 2.0 準拠、自由テキスト入力）</td>
@@ -495,10 +499,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
         <td style="padding:2px 0;">ファイル情報（file35）入力UI実装：ファイル選択で名前・サイズ・MIME自動取得、権利情報URIからライセンス自動設定、TSV/プレビュー対応</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-13</td>
-        <td style="padding:2px 0;">科研費課題番号の識別方法修正：funder DOIに依存せず番号パターン（例: 23KF0079）で科研費を識別、KAKEN/CiNii検索が正しく実行されるよう修正</td>
       </tr>
     </tbody>
   </table>

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -454,18 +454,36 @@ ItemType.json には複数レベルのネスト構造を持つフィールドが
 - **Level 2**:
   - `subitem_funder_names[]` - 複数言語による助成機関名
   - `subitem_funder_identifiers` - 助成機関識別子 (単一)
-  - `subitem_funding_streams[]` - 複数プログラム名
+  - `subitem_funding_stream_identifiers` - プログラム情報識別子（JPCOAR 2.0、単一）
+  - `subitem_funding_streams[]` - 複数言語によるプログラム情報（JPCOAR 2.0）
+  - `subitem_award_numbers` - 研究課題番号（単一）
   - `subitem_award_titles[]` - 複数言語による研究課題名
 
+**表示順序**: 助成機関識別子 → 助成機関名 → プログラム情報識別子 → プログラム情報 → 研究課題番号 → 研究課題名
+
 **要件**:
-- 複数言語バージョンの助成機関名・課題名をサポート
+- 複数言語バージョンの助成機関名・課題名・プログラム情報をサポート
 - アコーディオンUIで複数プログラム情報を管理
+
+**プログラム情報（JPCOAR 2.0 fundingStream / fundingStreamIdentifier）**（[issue #34](https://github.com/tzhaya/jc-import-file-maker/issues/34)）:
+- `subitem_funding_stream_identifiers`: プログラム情報識別子（単一オブジェクト）
+  - `subitem_funding_stream_identifier`: 識別子値
+  - `subitem_funding_stream_identifier_type`: 識別子タイプ（`Crossref Funder` / `JGN_fundingStream`）
+  - `subitem_funding_stream_identifier_type_uri`: 識別子タイプURI
+- `subitem_funding_streams[]`: プログラム情報（配列、複数言語対応）
+  - `subitem_funding_stream`: プログラム情報テキスト
+  - `subitem_funding_stream_language`: 言語
+- JGN連携成功時: `funding.scheme` からプログラム情報を取得し、課題番号から `JGN_fundingStream` コードを自動抽出して識別子に設定
+- KAKENHI課題（`isKakenhi()` 合致）の場合: `KAKENHI_FUNDING_STREAM` 定数（「科学研究費助成事業」(ja) / 「Grants-in-Aid for Scientific Research (KAKENHI)」(en)）を自動設定、識別子は空
+- 上記以外: 空配列・空オブジェクトを設定（ユーザーが手動入力可能）
 
 **JGN連携（Crossref JGN API）**:
 - award番号が `JP` で始まる場合、Crossref の JGN（Japan Grant Number）API（`https://api.crossref.org/works/10.52926/{award}`）を照会する
 - レスポンスが `type: "grant"` の場合のみ処理実行
 - `project[0].project-title[].title` を課題名、`.language` を言語として `subitem_award_titles[]` に設定
-- `funder[0].name` を助成機関名、`funder[0].DOI` を助成機関識別子として返す（助成機関名・識別子が空の場合に補完）
+- `project[0].funding[0].funder` から助成機関名（`.name`）・助成機関識別子（`.id[]` の DOI タイプ）を取得（助成機関名・識別子が空の場合に補完）
+- `project[0].funding[0].scheme` からプログラム情報を取得し `subitem_funding_streams[]` に設定
+- 課題番号から JGN_fundingStream コードを自動抽出し `subitem_funding_stream_identifiers` に設定
 - `https://doi.org/10.52926/{award}` を `subitem_award_uri` に設定
 - 404（JGN未登録）の場合は null を返し、KAKEN連携にフォールバック
 - JGN連携が成功した場合、KAKEN連携はスキップ

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -16,6 +16,7 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.3.5 | 2026-03-15 | 助成情報プログラム情報の表示順序修正（#34） |
 | 1.3.4 | 2026-03-15 | 助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0）（#34） |
 | 1.3.3 | 2026-03-14 | 作成者タイプ creatorType 初期値を空値に変更（#27） |
 | 1.3.2 | 2026-03-14 | 識別子スキーム語彙 JPCOAR 2.0 対応（#26） |
@@ -49,7 +50,8 @@ JPCOAR スキーマ 2.0 で `jpcoar:fundingReference` に新しいサブフィ�
    - その他 → 空値
 
 4. **renderOneFunder() UI 追加**
-   - 研究課題名の後に「プログラム情報識別子」（3フィールド）と「プログラム情報」（配列型）の入力セクションを追加
+   - 助成機関名の後、研究課題番号の前に「プログラム情報識別子」（3フィールド）と「プログラム情報」（配列型）の入力セクションを追加
+   - 表示順序: 助成機関識別子 → 助成機関名 → プログラム情報識別子 → プログラム情報 → 研究課題番号 → 研究課題名
    - 「助成機関を検索」ボタンのハンドラにプログラム情報の自動設定ロジックを追加
 
 5. **collectFundingField() 拡張**
@@ -57,6 +59,7 @@ JPCOAR スキーマ 2.0 で `jpcoar:fundingReference` に新しいサブフィ�
 
 6. **buildFundingPreview() 拡張**
    - プレビューテーブルに「プログラム情報」列を追加（識別子とプログラム名を表示）
+   - 列順序: #/助成機関名/識別子/プログラム情報/課題番号/課題名
 
 ### テスト結果
 E2E テスト（DOI: `10.1038/s41467-023-40773-1`）で以下を確認：
@@ -66,7 +69,8 @@ E2E テスト（DOI: `10.1038/s41467-023-40773-1`）で以下を確認：
 ### 変更箇所
 - `make_jc_importer.html`: 定数追加、fetchJgn()、buildFunders()、buildJaLCFunders()、renderOneFunder()、collectFundingField()、buildFundingPreview() 拡張
 - `chrome-extension/make_jc_importer.js`: 同上を同期
-- `chrome-extension/manifest.json`: 1.3.3 → 1.3.4
+- `chrome-extension/manifest.json`: 1.3.3 → 1.3.4 → 1.3.5（表示順序修正）
+- `chrome-extension/panel.html`: 更新概要テーブル同期
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -458,7 +458,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-03-14 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-03-15 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -470,6 +470,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-15</td>
+        <td style="padding:2px 0;">助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0）、表示順序を助成機関→プログラム情報→研究課題番号に修正</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
         <td style="padding:2px 0;">作成者タイプ（creatorType）の初期値を空値に変更（JPCOAR 2.0 準拠、自由テキスト入力）</td>
@@ -485,10 +489,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
         <td style="padding:2px 0;">ファイル情報（file35）入力UI実装：ファイル選択で名前・サイズ・MIME自動取得、権利情報URIからライセンス自動設定、TSV/プレビュー対応</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-13</td>
-        <td style="padding:2px 0;">科研費課題番号の識別方法修正：funder DOIに依存せず番号パターン（例: 23KF0079）で科研費を識別、KAKEN/CiNii検索が正しく実行されるよう修正</td>
       </tr>
     </tbody>
   </table>
@@ -3893,6 +3893,32 @@ function renderOneFunder(funder, idx, defLabel) {
   });
   updateFunderLookup = updateFV;
 
+  // プログラム情報識別子（JPCOAR 2.0 fundingStreamIdentifier）
+  const fsId = funder.subitem_funding_stream_identifiers || {};
+  fundContent.appendChild(createFieldRow('プログラム情報識別子', fsId.subitem_funding_stream_identifier || '', 'text', null,
+    { fieldKey: 'subitem_funding_stream_identifier' }));
+  fundContent.appendChild(createFieldRow('識別子タイプ', fsId.subitem_funding_stream_identifier_type || '', 'select',
+    'subitem_funding_stream_identifier_type', { fieldKey: 'subitem_funding_stream_identifier_type' }));
+  fundContent.appendChild(createFieldRow('識別子タイプURI', fsId.subitem_funding_stream_identifier_type_uri || '', 'text', null,
+    { fieldKey: 'subitem_funding_stream_identifier_type_uri' }));
+
+  // プログラム情報（JPCOAR 2.0 fundingStream、配列）
+  const { wrapper: fsWrap, content: fsCont } = createNestedSectionHeader('プログラム情報', 2, (cont) => {
+    const { grp, delBtn } = createEntryGroup();
+    grp.appendChild(createFieldRow('プログラム情報', '', 'text', null, { fieldKey: 'subitem_funding_stream' }));
+    grp.appendChild(createFieldRow('言語', '', 'select', 'language', { fieldKey: 'subitem_funding_stream_language' }));
+    grp.appendChild(delBtn);
+    cont.appendChild(grp);
+  });
+  (funder.subitem_funding_streams || []).forEach(fs => {
+    const { grp, delBtn } = createEntryGroup();
+    grp.appendChild(createFieldRow('プログラム情報', fs.subitem_funding_stream || '', 'text', null, { fieldKey: 'subitem_funding_stream' }));
+    grp.appendChild(createFieldRow('言語', fs.subitem_funding_stream_language || '', 'select', 'language', { fieldKey: 'subitem_funding_stream_language' }));
+    grp.appendChild(delBtn);
+    fsCont.appendChild(grp);
+  });
+  fundContent.appendChild(fsWrap);
+
   // 研究課題番号（fieldset）+ 助成機関を検索ボタン
   const aw = funder.subitem_award_numbers || {};
   const awardRow = createFieldRow('研究課題番号', aw.subitem_award_number || '', 'text', null, { fieldKey: 'subitem_award_number' });
@@ -3926,32 +3952,6 @@ function renderOneFunder(funder, idx, defLabel) {
     atCont.appendChild(grp);
   });
   fundContent.appendChild(atWrap);
-
-  // プログラム情報識別子（JPCOAR 2.0 fundingStreamIdentifier）
-  const fsId = funder.subitem_funding_stream_identifiers || {};
-  fundContent.appendChild(createFieldRow('プログラム情報識別子', fsId.subitem_funding_stream_identifier || '', 'text', null,
-    { fieldKey: 'subitem_funding_stream_identifier' }));
-  fundContent.appendChild(createFieldRow('識別子タイプ', fsId.subitem_funding_stream_identifier_type || '', 'select',
-    'subitem_funding_stream_identifier_type', { fieldKey: 'subitem_funding_stream_identifier_type' }));
-  fundContent.appendChild(createFieldRow('識別子タイプURI', fsId.subitem_funding_stream_identifier_type_uri || '', 'text', null,
-    { fieldKey: 'subitem_funding_stream_identifier_type_uri' }));
-
-  // プログラム情報（JPCOAR 2.0 fundingStream、配列）
-  const { wrapper: fsWrap, content: fsCont } = createNestedSectionHeader('プログラム情報', 2, (cont) => {
-    const { grp, delBtn } = createEntryGroup();
-    grp.appendChild(createFieldRow('プログラム情報', '', 'text', null, { fieldKey: 'subitem_funding_stream' }));
-    grp.appendChild(createFieldRow('言語', '', 'select', 'language', { fieldKey: 'subitem_funding_stream_language' }));
-    grp.appendChild(delBtn);
-    cont.appendChild(grp);
-  });
-  (funder.subitem_funding_streams || []).forEach(fs => {
-    const { grp, delBtn } = createEntryGroup();
-    grp.appendChild(createFieldRow('プログラム情報', fs.subitem_funding_stream || '', 'text', null, { fieldKey: 'subitem_funding_stream' }));
-    grp.appendChild(createFieldRow('言語', fs.subitem_funding_stream_language || '', 'select', 'language', { fieldKey: 'subitem_funding_stream_language' }));
-    grp.appendChild(delBtn);
-    fsCont.appendChild(grp);
-  });
-  fundContent.appendChild(fsWrap);
 
   // 助成機関を検索ボタンの結果表示エリアとイベントハンドラ
   const awardResultEl = document.createElement('div');
@@ -5466,7 +5466,7 @@ function buildFundingPreview(funders) {
   if (!nonEmpty.length) return '';
 
   let html = '<table class="pv-inner-table"><thead><tr>';
-  html += '<th>#</th><th>\u52A9\u6210\u6A5F\u95A2\u540D</th><th>\u8B58\u5225\u5B50</th><th>\u8AB2\u984C\u756A\u53F7</th><th>\u8AB2\u984C\u540D</th><th>\u30D7\u30ED\u30B0\u30E9\u30E0\u60C5\u5831</th>';
+  html += '<th>#</th><th>\u52A9\u6210\u6A5F\u95A2\u540D</th><th>\u8B58\u5225\u5B50</th><th>\u30D7\u30ED\u30B0\u30E9\u30E0\u60C5\u5831</th><th>\u8AB2\u984C\u756A\u53F7</th><th>\u8AB2\u984C\u540D</th>';
   html += '</tr></thead><tbody>';
 
   nonEmpty.forEach((f, i) => {
@@ -5476,12 +5476,6 @@ function buildFundingPreview(funders) {
     const idStr = fId.subitem_funder_identifier
       ? (fId.subitem_funder_identifier_type ? fId.subitem_funder_identifier_type + ': ' : '') + fmtVal(fId.subitem_funder_identifier)
       : '';
-    const aw = f.subitem_award_numbers || {};
-    const awardStr = aw.subitem_award_number
-      ? fmtVal(aw.subitem_award_number) + (aw.subitem_award_uri ? ' (' + fmtVal(aw.subitem_award_uri) + ')' : '')
-      : '';
-    const titles = (f.subitem_award_titles || []).filter(t => t.subitem_award_title)
-      .map(t => fmtVal(t.subitem_award_title, t.subitem_award_title_language)).join('<br>');
     // プログラム情報
     const streams = (f.subitem_funding_streams || []).filter(s => s.subitem_funding_stream)
       .map(s => fmtVal(s.subitem_funding_stream, s.subitem_funding_stream_language)).join('<br>');
@@ -5490,7 +5484,13 @@ function buildFundingPreview(funders) {
       ? (fsIdObj.subitem_funding_stream_identifier_type ? fsIdObj.subitem_funding_stream_identifier_type + ': ' : '') + fmtVal(fsIdObj.subitem_funding_stream_identifier)
       : '';
     const streamCol = [fsIdStr, streams].filter(Boolean).join('<br>');
-    html += '<tr><td>' + i + '</td><td>' + names + '</td><td>' + idStr + '</td><td>' + awardStr + '</td><td>' + titles + '</td><td>' + streamCol + '</td></tr>';
+    const aw = f.subitem_award_numbers || {};
+    const awardStr = aw.subitem_award_number
+      ? fmtVal(aw.subitem_award_number) + (aw.subitem_award_uri ? ' (' + fmtVal(aw.subitem_award_uri) + ')' : '')
+      : '';
+    const titles = (f.subitem_award_titles || []).filter(t => t.subitem_award_title)
+      .map(t => fmtVal(t.subitem_award_title, t.subitem_award_title_language)).join('<br>');
+    html += '<tr><td>' + i + '</td><td>' + names + '</td><td>' + idStr + '</td><td>' + streamCol + '</td><td>' + awardStr + '</td><td>' + titles + '</td></tr>';
   });
   html += '</tbody></table>';
   return html;
@@ -5703,7 +5703,7 @@ if (!CONFIG.CiNii_API_KEY || CONFIG.CiNii_API_KEY === 'YOUR_CiNii_API_KEY') {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-03-14';
+  const LOCAL_VERSION = '2026-03-15';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;


### PR DESCRIPTION
## Summary
- 助成情報セクションのフィールド表示順序を修正：助成機関識別子→助成機関名→**プログラム情報識別子→プログラム情報**→研究課題番号→研究課題名
- プレビューテーブルの列順序も同様に修正
- Issue #34 マージ時に不足していたドキュメント更新を補完（README.md変更履歴、version-info、LOCAL_VERSION、manifest.json、requirements.md、worklog.md）

## Test plan
- [x] E2E テスト `10.1038/s41467-023-40773-1` ALL PASSED（KAKENHI 5件 + JGN 1件の助成情報確認）
- [x] funder テスト `JP16K07412`（科研費）ALL PASSED
- [x] funder テスト `JPMJSA1907`（JST/JGN）ALL PASSED

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)