### PR TITLE
feat: resourceType 語彙を JPCOAR 2.0 準拠に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Chrome拡張版と通常ブラウザ版の2つの利用方法があります。
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張版 | 2026-03-15 | ver. 1.3.5 | 助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0）、表示順序修正（[#34](https://github.com/tzhaya/jc-import-file-maker/issues/34)） |
-| インポート用TSV生成ツール | 2026-03-15 | — | 助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0）、表示順序修正（[#34](https://github.com/tzhaya/jc-import-file-maker/issues/34)） |
+| Chrome拡張版 | 2026-03-15 | ver. 1.3.6 | 資源タイプ語彙を JPCOAR 2.0 準拠に更新（[#31](https://github.com/tzhaya/jc-import-file-maker/issues/31)） |
+| インポート用TSV生成ツール | 2026-03-15 | — | 資源タイプ語彙を JPCOAR 2.0 準拠に更新（[#31](https://github.com/tzhaya/jc-import-file-maker/issues/31)） |
 | 助成情報検索ツール | 2026-03-13 | — | isKakenhi()関数追加（科研費番号パターン判定） |
 
 ## 導入方法
@@ -256,6 +256,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-15 | 資源タイプ語彙を JPCOAR 2.0 準拠に更新：TITLE_MAPS.resourcetype から v1.0 廃止語彙（internal report・report part）を削除、CROSSREF_TYPE_MAP の report-component マッピング修正、getDoiCategory() に v2.0 新タイプ追加（[#31](https://github.com/tzhaya/jc-import-file-maker/issues/31)） |
 | 2026-03-15 | 助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0 fundingStream / fundingStreamIdentifier）：JGN APIからプログラム情報を自動取得、KAKENHI課題には固定値を自動設定、表示順序を助成機関→プログラム情報→研究課題番号に修正（[#34](https://github.com/tzhaya/jc-import-file-maker/issues/34)） |
 | 2026-03-14 | 作成者タイプ（creatorType）の初期値を空値に変更（JPCOAR 2.0 では自由テキスト定義のため、API取得時も空値とする）（[#27](https://github.com/tzhaya/jc-import-file-maker/issues/27)） |
 | 2026-03-14 | 識別子スキーム語彙を JPCOAR 2.0 準拠に更新：nameIdentifierScheme に e-Rad_Researcher・NRID・kakenhi を追加、affiliationNameIdentifierScheme の非推奨スキーム（GRID・kakenhi）を末尾に移動（[#26](https://github.com/tzhaya/jc-import-file-maker/issues/26)） |

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -83,7 +83,7 @@ const RESOURCE_TYPE_MAP = {
   'journal article':          'http://purl.org/coar/resource_type/c_6501',
   'newspaper':                'http://purl.org/coar/resource_type/c_2fe3',
   'other periodical':         'http://purl.org/coar/resource_type/QX5C-AR31', // v2.0追加
-  'periodical':               'http://purl.org/coar/resource_type/c_2659',    // v1.0のみ
+  'periodical':               'http://purl.org/coar/resource_type/c_2659',    // v1.0のみ（JPCOAR 2.0で廃止、UI非表示）
   'review article':           'http://purl.org/coar/resource_type/c_dcae04bc',
   'software paper':           'http://purl.org/coar/resource_type/c_7bab',
   'article':                  'http://purl.org/coar/resource_type/c_6501',
@@ -95,7 +95,7 @@ const RESOURCE_TYPE_MAP = {
   'map':                      'http://purl.org/coar/resource_type/c_12cd',
   // ----- Conference Output -----
   'conference output':        'http://purl.org/coar/resource_type/c_c94f',    // v2.0改称（旧: conference object）
-  'conference object':        'http://purl.org/coar/resource_type/c_c94f',    // 後方互換
+  'conference object':        'http://purl.org/coar/resource_type/c_c94f',    // v1.0のみ（→ conference output に改称、後方互換）
   'conference presentation':  'http://purl.org/coar/resource_type/R60J-J5BD', // v2.0追加
   'conference proceedings':   'http://purl.org/coar/resource_type/c_f744',
   'conference poster':        'http://purl.org/coar/resource_type/c_6670',
@@ -115,7 +115,7 @@ const RESOURCE_TYPE_MAP = {
   'simulation data':          'http://purl.org/coar/resource_type/W2XT-7017', // v2.0追加
   'survey data':              'http://purl.org/coar/resource_type/NHD0-W6SY', // v2.0追加
   // ----- Image -----
-  'interview':                'http://purl.org/coar/resource_type/c_26e4',    // v1.0のみ
+  'interview':                'http://purl.org/coar/resource_type/c_26e4',    // v1.0のみ（JPCOAR 2.0で廃止、UI非表示）
   'image':                    'http://purl.org/coar/resource_type/c_c513',
   'still image':              'http://purl.org/coar/resource_type/c_ecc8',
   'moving image':             'http://purl.org/coar/resource_type/c_8a7e',
@@ -132,12 +132,12 @@ const RESOURCE_TYPE_MAP = {
   'trademark':                'http://purl.org/coar/resource_type/H6QP-SC1X', // v2.0追加
   'utility model':            'http://purl.org/coar/resource_type/9DKX-KSAF', // v2.0追加
   // ----- Report -----
-  'internal report':          'http://purl.org/coar/resource_type/c_18ww',    // v1.0のみ
+  'internal report':          'http://purl.org/coar/resource_type/c_18ww',    // v1.0のみ（JPCOAR 2.0で廃止、UI非表示）
   'report':                   'http://purl.org/coar/resource_type/c_93fc',
   'research report':          'http://purl.org/coar/resource_type/c_18ws',
   'technical report':         'http://purl.org/coar/resource_type/c_18gh',
   'policy report':            'http://purl.org/coar/resource_type/c_186u',
-  'report part':              'http://purl.org/coar/resource_type/c_ba1f',    // v1.0のみ
+  'report part':              'http://purl.org/coar/resource_type/c_ba1f',    // v1.0のみ（JPCOAR 2.0で廃止、UI非表示）
   'working paper':            'http://purl.org/coar/resource_type/c_8042',
   'data management plan':     'http://purl.org/coar/resource_type/c_ab20',
   // ----- Sound -----
@@ -185,7 +185,7 @@ const CROSSREF_TYPE_MAP = {
   'posted-content':      'article',
   'peer-review':         'article',
   'report-series':       'report',
-  'report-component':    'report part',
+  'report-component':    'report',           // report part はJPCOAR 2.0で廃止
   'journal-volume':      'journal',
   'journal-issue':       'journal',
   'database':            'dataset',
@@ -424,8 +424,8 @@ const TITLE_MAPS = {
     'lecture',
     'design patent','patent','PCT application','plant patent','plant variety protection',
     'software patent','trademark','utility model',
-    'internal report','report','research report','technical report',
-    'policy report','report part','working paper','data management plan',
+    'report','research report','technical report',
+    'policy report','working paper','data management plan',
     'sound','thesis','bachelor thesis','master thesis','doctoral thesis',
     'commentary','design','industrial design','interactive resource','layout design',
     'learning object','manuscript','musical notation','peer review',
@@ -2462,10 +2462,12 @@ function renumberItems(container) {
 // 資源タイプ → 別表カテゴリ（'article' | 'book' | null）
 function getDoiCategory(resourceType) {
   const bookTypes = ['book','book part','technical report','research report','report',
+                     'policy report','working paper',
                      'thesis','bachelor thesis','master thesis','doctoral thesis'];
   const articleTypes = ['conference paper','departmental bulletin paper','journal article',
                         'review article','data paper','editorial','article','newspaper',
-                        'software paper','other'];
+                        'software paper','journal','other periodical',
+                        'commentary','peer review','other'];
   if (articleTypes.includes(resourceType)) return 'article';
   if (bookTypes.includes(resourceType)) return 'book';
   return null;

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "DOIからJAIRO Cloud インポート用TSVを生成するツール。CORS非対応APIへのアクセスとAPIキー管理を提供します。",
   "permissions": ["storage", "sidePanel"],
   "host_permissions": [

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -482,6 +482,10 @@
     <tbody>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-15</td>
+        <td style="padding:2px 0;">資源タイプ語彙を JPCOAR 2.0 準拠に更新：v1.0廃止語彙をUI非表示、DOIカテゴリにv2.0新タイプ追加</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-15</td>
         <td style="padding:2px 0;">助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0）、表示順序を助成機関→プログラム情報→研究課題番号に修正</td>
       </tr>
       <tr>
@@ -495,10 +499,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
         <td style="padding:2px 0;">言語選択肢に ja-Latn（ローマ字ヨミ）を追加（JPCOAR 2.0 / WEKO3 LANGUAGE_VAL2_1 準拠）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
-        <td style="padding:2px 0;">ファイル情報（file35）入力UI実装：ファイル選択で名前・サイズ・MIME自動取得、権利情報URIからライセンス自動設定、TSV/プレビュー対応</td>
       </tr>
     </tbody>
   </table>

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -42,7 +42,8 @@ make_jc_importer.html
 
 **資源タイプ語彙別表**
     -　`resource_type_vocabulary.md`
-    - JPCOAR スキーマ 2.0 の語彙に対応（v2.0追加型・v1.0のみ型を区分表示）
+    - JPCOAR スキーマ 2.0 の語彙に対応（全74タイプ）
+    - v1.0のみの廃止語彙（`internal report`・`report part`・`periodical`・`interview`・`conference object`）は `RESOURCE_TYPE_MAP` に後方互換として残すが、UI選択肢（`TITLE_MAPS.resourcetype`）からは除外
     - 出典: v1.0 https://schema.irdb.nii.ac.jp/ja/resource_type_vocabulary / v2.0 https://schema.irdb.nii.ac.jp/ja/2.0/resource_type_vocabulary
 
 **JPCOARスキーマ 項目別説明リンク一覧**
@@ -131,8 +132,8 @@ make_jc_importer.html
     -   JaLC: 青系（`#e3f2fd` 背景）、Crossref: 赤系（`#fce4ec` 背景）
     -   バッジにマウスホバーするとツールチップで備考（例: `Crossref: xml:lang必須`）を確認可能
     -   資源タイプ（`item_30002_resource_type13.resourcetype`）の選択値に応じて動的に切り替える
-        -   ジャーナルアーティクル系（`journal article`, `conference paper`, `departmental bulletin paper` 等）: 別表2-1/3-1 に基づくバッジを表示
-        -   書籍系（`book`, `book part`, `technical report`, `thesis` 等）: 別表2-3/3-2 に基づくバッジを表示
+        -   ジャーナルアーティクル系（`journal article`, `conference paper`, `departmental bulletin paper`, `journal`, `other periodical`, `commentary`, `peer review` 等）: 別表2-1/3-1 に基づくバッジを表示
+        -   書籍系（`book`, `book part`, `technical report`, `policy report`, `working paper`, `thesis` 等）: 別表2-3/3-2 に基づくバッジを表示
         -   対象外の資源タイプ（`image`, `dataset` 等）: バッジ非表示
     -   資源タイプ変更時および初期表示時（`renderAll()` 完了後）にバッジを自動更新する
     -   根拠: `docs/JPCOAR_JaLC_Crossref_requirements.md`（JPCOAR/JaLC対照表 付録 ver.1.5）

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-15（助成情報にプログラム情報識別子・プログラム情報を追加 #34）
+最終更新: 2026-03-15（資源タイプ語彙を JPCOAR 2.0 準拠に更新 #31）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -16,6 +16,7 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.3.6 | 2026-03-15 | 資源タイプ語彙を JPCOAR 2.0 準拠に更新（#31） |
 | 1.3.5 | 2026-03-15 | 助成情報プログラム情報の表示順序修正（#34） |
 | 1.3.4 | 2026-03-15 | 助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0）（#34） |
 | 1.3.3 | 2026-03-14 | 作成者タイプ creatorType 初期値を空値に変更（#27） |
@@ -26,6 +27,34 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 | 1.2.0 | 2026-03-13 | TSVエクスポート機能追加、残存issues優先順位整理 |
 | 1.1.0 | 2026-03-11 | OpenSearch検索タブ統合、JaLCデータ取込修正、書誌情報UI修正、入力モード自動判定 |
 | 1.0.0 | 2026-03-10 | 初期リリース（Manifest V3、Service Worker、OPFモーダル） |
+
+---
+
+## 2026-03-15: 資源タイプ語彙を JPCOAR 2.0 準拠に更新（#31）
+
+### 背景
+JPCOAR スキーマ 2.0 で `resourceType` の語彙別表が改訂された。v1.0 限定の廃止語彙がUI選択肢に残存し、CROSSREF_TYPE_MAP が廃止語彙を参照し、v2.0 で追加されたタイプが DOI 必須項目カテゴリに未登録であった。
+
+### 変更内容
+
+1. **`RESOURCE_TYPE_MAP` コメント整理**
+   - v1.0 限定エントリ（`periodical`・`interview`・`internal report`・`report part`・`conference object`）のコメントに `JPCOAR 2.0で廃止、UI非表示` を明記
+   - 後方互換のため MAP エントリ自体は削除しない
+
+2. **`TITLE_MAPS.resourcetype` から v1.0 廃止語彙を削除**
+   - `internal report`・`report part` をUI選択肢から除外（JPCOAR 2.0 語彙別表 全74タイプに準拠）
+
+3. **`CROSSREF_TYPE_MAP` の修正**
+   - `report-component` のマッピング先を `report part`（廃止）から `report` に変更
+
+4. **`getDoiCategory()` の拡張**
+   - articleTypes に追加: `journal`・`other periodical`・`commentary`・`peer review`
+   - bookTypes に追加: `policy report`・`working paper`
+
+5. **`chrome-extension/make_jc_importer.js` に全変更を同期**
+
+### 検証
+- JPCOAR 2.0 公式語彙別表（ https://schema.irdb.nii.ac.jp/ja/2.0/resource_type_vocabulary ）と COAR Vocabulary 3.2 の両方でURI・ラベルを照合し、全74タイプが正確であることを確認
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -472,6 +472,10 @@
     <tbody>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-15</td>
+        <td style="padding:2px 0;">資源タイプ語彙を JPCOAR 2.0 準拠に更新：v1.0廃止語彙をUI非表示、DOIカテゴリにv2.0新タイプ追加</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-15</td>
         <td style="padding:2px 0;">助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0）、表示順序を助成機関→プログラム情報→研究課題番号に修正</td>
       </tr>
       <tr>
@@ -485,10 +489,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
         <td style="padding:2px 0;">言語選択肢に ja-Latn（ローマ字ヨミ）を追加（JPCOAR 2.0 / WEKO3 LANGUAGE_VAL2_1 準拠）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-14</td>
-        <td style="padding:2px 0;">ファイル情報（file35）入力UI実装：ファイル選択で名前・サイズ・MIME自動取得、権利情報URIからライセンス自動設定、TSV/プレビュー対応</td>
       </tr>
     </tbody>
   </table>
@@ -668,7 +668,7 @@ const RESOURCE_TYPE_MAP = {
   'journal article':          'http://purl.org/coar/resource_type/c_6501',
   'newspaper':                'http://purl.org/coar/resource_type/c_2fe3',
   'other periodical':         'http://purl.org/coar/resource_type/QX5C-AR31', // v2.0追加
-  'periodical':               'http://purl.org/coar/resource_type/c_2659',    // v1.0のみ
+  'periodical':               'http://purl.org/coar/resource_type/c_2659',    // v1.0のみ（JPCOAR 2.0で廃止、UI非表示）
   'review article':           'http://purl.org/coar/resource_type/c_dcae04bc',
   'software paper':           'http://purl.org/coar/resource_type/c_7bab',
   'article':                  'http://purl.org/coar/resource_type/c_6501',
@@ -680,7 +680,7 @@ const RESOURCE_TYPE_MAP = {
   'map':                      'http://purl.org/coar/resource_type/c_12cd',
   // ----- Conference Output -----
   'conference output':        'http://purl.org/coar/resource_type/c_c94f',    // v2.0改称（旧: conference object）
-  'conference object':        'http://purl.org/coar/resource_type/c_c94f',    // 後方互換
+  'conference object':        'http://purl.org/coar/resource_type/c_c94f',    // v1.0のみ（→ conference output に改称、後方互換）
   'conference presentation':  'http://purl.org/coar/resource_type/R60J-J5BD', // v2.0追加
   'conference proceedings':   'http://purl.org/coar/resource_type/c_f744',
   'conference poster':        'http://purl.org/coar/resource_type/c_6670',
@@ -700,7 +700,7 @@ const RESOURCE_TYPE_MAP = {
   'simulation data':          'http://purl.org/coar/resource_type/W2XT-7017', // v2.0追加
   'survey data':              'http://purl.org/coar/resource_type/NHD0-W6SY', // v2.0追加
   // ----- Image -----
-  'interview':                'http://purl.org/coar/resource_type/c_26e4',    // v1.0のみ
+  'interview':                'http://purl.org/coar/resource_type/c_26e4',    // v1.0のみ（JPCOAR 2.0で廃止、UI非表示）
   'image':                    'http://purl.org/coar/resource_type/c_c513',
   'still image':              'http://purl.org/coar/resource_type/c_ecc8',
   'moving image':             'http://purl.org/coar/resource_type/c_8a7e',
@@ -717,12 +717,12 @@ const RESOURCE_TYPE_MAP = {
   'trademark':                'http://purl.org/coar/resource_type/H6QP-SC1X', // v2.0追加
   'utility model':            'http://purl.org/coar/resource_type/9DKX-KSAF', // v2.0追加
   // ----- Report -----
-  'internal report':          'http://purl.org/coar/resource_type/c_18ww',    // v1.0のみ
+  'internal report':          'http://purl.org/coar/resource_type/c_18ww',    // v1.0のみ（JPCOAR 2.0で廃止、UI非表示）
   'report':                   'http://purl.org/coar/resource_type/c_93fc',
   'research report':          'http://purl.org/coar/resource_type/c_18ws',
   'technical report':         'http://purl.org/coar/resource_type/c_18gh',
   'policy report':            'http://purl.org/coar/resource_type/c_186u',
-  'report part':              'http://purl.org/coar/resource_type/c_ba1f',    // v1.0のみ
+  'report part':              'http://purl.org/coar/resource_type/c_ba1f',    // v1.0のみ（JPCOAR 2.0で廃止、UI非表示）
   'working paper':            'http://purl.org/coar/resource_type/c_8042',
   'data management plan':     'http://purl.org/coar/resource_type/c_ab20',
   // ----- Sound -----
@@ -770,7 +770,7 @@ const CROSSREF_TYPE_MAP = {
   'posted-content':      'article',
   'peer-review':         'article',
   'report-series':       'report',
-  'report-component':    'report part',
+  'report-component':    'report',           // report part はJPCOAR 2.0で廃止
   'journal-volume':      'journal',
   'journal-issue':       'journal',
   'database':            'dataset',
@@ -1009,8 +1009,8 @@ const TITLE_MAPS = {
     'lecture',
     'design patent','patent','PCT application','plant patent','plant variety protection',
     'software patent','trademark','utility model',
-    'internal report','report','research report','technical report',
-    'policy report','report part','working paper','data management plan',
+    'report','research report','technical report',
+    'policy report','working paper','data management plan',
     'sound','thesis','bachelor thesis','master thesis','doctoral thesis',
     'commentary','design','industrial design','interactive resource','layout design',
     'learning object','manuscript','musical notation','peer review',
@@ -3047,10 +3047,12 @@ function renumberItems(container) {
 // 資源タイプ → 別表カテゴリ（'article' | 'book' | null）
 function getDoiCategory(resourceType) {
   const bookTypes = ['book','book part','technical report','research report','report',
+                     'policy report','working paper',
                      'thesis','bachelor thesis','master thesis','doctoral thesis'];
   const articleTypes = ['conference paper','departmental bulletin paper','journal article',
                         'review article','data paper','editorial','article','newspaper',
-                        'software paper','other'];
+                        'software paper','journal','other periodical',
+                        'commentary','peer review','other'];
   if (articleTypes.includes(resourceType)) return 'article';
   if (bookTypes.includes(resourceType)) return 'book';
   return null;


### PR DESCRIPTION
## Summary

- JPCOAR 2.0 公式語彙別表（全74タイプ）および COAR Vocabulary 3.2 と照合し、資源タイプ関連の定数・UI選択肢・DOIカテゴリを更新
- `TITLE_MAPS.resourcetype` から v1.0 廃止語彙（`internal report`・`report part`）を削除
- `CROSSREF_TYPE_MAP` の `report-component` マッピング先を `report part`（廃止）→ `report` に修正
- `getDoiCategory()` に v2.0 新タイプを追加（articleTypes: `journal`・`other periodical`・`commentary`・`peer review`、bookTypes: `policy report`・`working paper`）
- `RESOURCE_TYPE_MAP` の v1.0 限定エントリは後方互換として保持し、コメントに「JPCOAR 2.0で廃止、UI非表示」を明記
- Chrome拡張版（`make_jc_importer.js`・`panel.html`・`manifest.json` v1.3.6）に同期

Closes #31

## Test plan

- [x] E2E テスト ALL PASSED（DOI: `10.1038/s41467-023-40773-1`、資源タイプ: journal article）
- [x] funder テスト ALL PASSED（課題番号: `JP16K07412`）
- [x] 資源タイプのドロップダウンに `internal report`・`report part` が表示されないこと
- [x] `journal`・`commentary` 等の新タイプ選択時にDOI必須項目バッジが表示されること
- [x] Chrome拡張版で同一の動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)