### PR TITLE
fix: 助成情報検索ツールの課題番号抽出を改善（#104）

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Chrome拡張版と通常ブラウザ版の2つの利用方法があります。
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張版 | 2026-03-15 | ver. 1.3.7 | JPCOARスキーマ説明リンクを2.0に更新、下位項目にもスキーマリンクを追加（[#87](https://github.com/tzhaya/jc-import-file-maker/issues/87)） |
+| Chrome拡張版 | 2026-03-17 | ver. 1.3.8 | 助成情報検索ツールの課題番号抽出を改善：セミコロン・カンマ区切り入力対応、Ackテキストから科研費番号を抽出（[#104](https://github.com/tzhaya/jc-import-file-maker/issues/104)） |
 | インポート用TSV生成ツール | 2026-03-15 | — | JPCOARスキーマ説明リンクを2.0に更新、下位項目にもスキーマリンクを追加（[#87](https://github.com/tzhaya/jc-import-file-maker/issues/87)） |
-| 助成情報検索ツール | 2026-03-13 | — | isKakenhi()関数追加（科研費番号パターン判定） |
+| 助成情報検索ツール | 2026-03-17 | — | 課題番号抽出を改善：セミコロン・カンマ区切り入力対応、Ackテキストから科研費番号を抽出（[#104](https://github.com/tzhaya/jc-import-file-maker/issues/104)） |
 
 ## 導入方法
 
@@ -256,6 +256,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-17 | 助成情報検索ツールの課題番号抽出を改善：セミコロン・カンマ区切り入力対応、Acknowledgementsテキストから科研費番号（JPプレフィックスなし）を抽出（[#104](https://github.com/tzhaya/jc-import-file-maker/issues/104)） |
 | 2026-03-15 | JPCOARスキーマ説明リンクを2.0に更新、下位項目（著者・助成情報・関連情報等）にもスキーマリンクを追加、JPCOARschema_guide.md を1.0.2/2.0併記に更新（[#87](https://github.com/tzhaya/jc-import-file-maker/issues/87)） |
 | 2026-03-15 | 資源タイプ語彙を JPCOAR 2.0 準拠に更新：TITLE_MAPS.resourcetype から v1.0 廃止語彙（internal report・report part）を削除、CROSSREF_TYPE_MAP の report-component マッピング修正、getDoiCategory() に v2.0 新タイプ追加（[#31](https://github.com/tzhaya/jc-import-file-maker/issues/31)） |
 | 2026-03-15 | 助成情報にプログラム情報識別子・プログラム情報を追加（JPCOAR 2.0 fundingStream / fundingStreamIdentifier）：JGN APIからプログラム情報を自動取得、KAKENHI課題には固定値を自動設定、表示順序を助成機関→プログラム情報→研究課題番号に修正（[#34](https://github.com/tzhaya/jc-import-file-maker/issues/34)） |

--- a/chrome-extension/funder_lookup.js
+++ b/chrome-extension/funder_lookup.js
@@ -338,22 +338,42 @@ function buildResultCards(results) {
 // ===== 検索結果の保持（TSV出力用） =====
 let lastResults = [];
 
+// 科研費課題番号パターン（Ackテキスト抽出用、isKakenhi() と同一ルール）
+const KAKENHI_RE = /\b\d{2}[A-Z]{1,2}\d{4,5}\b/gi;
+
 // ===== 入力から課題番号を抽出（自動判定） =====
 function extractAwardNumbers(input) {
   const numbers = [];
   const seen = new Set();
+  const addUnique = (v) => { if (v && !seen.has(v)) { seen.add(v); numbers.push(v); } };
+
   for (const line of input.split(/\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    if (/\s/.test(trimmed)) {
-      // スペースを含む行: Acknowledgementsテキストとして JP... パターンを抽出
-      const matches = trimmed.match(/JP[A-Za-z0-9]+/g) || [];
-      for (const m of matches) {
-        if (!seen.has(m)) { seen.add(m); numbers.push(m); }
-      }
+
+    if (!/\s/.test(trimmed)) {
+      // (A) スペースなし: そのまま1つの課題番号
+      addUnique(trimmed);
+      continue;
+    }
+
+    // スペースを含む行 → 区切りリストか Ack テキストか判定
+    const tokens = trimmed.split(/[;,]/).map(t => t.trim()).filter(Boolean);
+    const allLookLikeIds = tokens.length > 1
+      && tokens.every(t => /^[A-Za-z0-9._-]+$/.test(t));
+
+    if (allLookLikeIds) {
+      // (B) セミコロン/カンマ区切りの課題番号リスト
+      for (const t of tokens) addUnique(t);
     } else {
-      // スペースなし: 課題番号として扱う
-      if (!seen.has(trimmed)) { seen.add(trimmed); numbers.push(trimmed); }
+      // (C) Acknowledgementsテキスト: JP... パターン + 科研費パターンを抽出
+      const jpMatches = trimmed.match(/JP[A-Za-z0-9]+/g) || [];
+      const kakenMatches = trimmed.match(KAKENHI_RE) || [];
+      for (const m of jpMatches) addUnique(m);
+      for (const m of kakenMatches) {
+        // JP付きで既に抽出済みなら重複スキップ（JP21H04856 と 21H04856）
+        if (!seen.has(m) && !seen.has('JP' + m)) addUnique(m);
+      }
     }
   }
   return numbers;
@@ -584,7 +604,7 @@ async function copyTsvToClipboard(btn) {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-03-13';
+  const LOCAL_VERSION = '2026-03-17';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=funder_lookup.html&per_page=1');
     if (!res.ok) return;

--- a/chrome-extension/funder_panel.html
+++ b/chrome-extension/funder_panel.html
@@ -233,7 +233,7 @@
 </nav>
 <h1>助成情報検索ツール</h1>
 <p style="font-size:0.82em; color:#555; margin:4px 0 12px;">
-  最終更新: 2026-03-11 &nbsp;|&nbsp;
+  最終更新: 2026-03-17 &nbsp;|&nbsp;
   <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#555;">github.com/tzhaya/jc-import-file-maker</a>
   <span id="update-check"></span>
 </p>
@@ -241,7 +241,7 @@
 <div class="input-section">
   <label for="award-input">課題番号またはAcknowledgementsテキストを入力してください。</label>
   <textarea id="award-input" placeholder="JP21H01234&#10;JPMJSA1907&#10;21K12345&#10;&#10;または謝辞テキストをそのまま貼り付け:&#10;This work was supported by JST CREST (Grant No. JPMJCR2125)."></textarea>
-  <div class="hint">課題番号（1行に1つ）またはAcknowledgementsテキストを貼り付けると、課題番号を自動で抽出します。科研費課題番号（JP付き / なし）や JGN 課題番号に対応しています。</div>
+  <div class="hint">課題番号（1行に1つ、またはセミコロン・カンマ区切り）やAcknowledgementsテキストを貼り付けると、課題番号を自動で抽出します。科研費課題番号（JP付き / なし）や JGN 課題番号に対応しています。</div>
   <button class="btn" id="search-btn">検索</button>
 </div>
 <div class="hint">

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "DOIからJAIRO Cloud インポート用TSVを生成するツール。CORS非対応APIへのアクセスとAPIキー管理を提供します。",
   "permissions": ["storage", "sidePanel"],
   "host_permissions": [

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-15（JPCOARスキーマ説明リンクを2.0に更新 #87）
+最終更新: 2026-03-17（助成情報検索ツールの課題番号抽出改善 #104）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -16,6 +16,7 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.3.8 | 2026-03-17 | 助成情報検索ツールの課題番号抽出改善：セミコロン・カンマ区切り入力対応、Ackテキストから科研費番号抽出（#104） |
 | 1.3.7 | 2026-03-15 | JPCOARスキーマ説明リンクを2.0に更新、下位項目にもスキーマリンクを追加（#87） |
 | 1.3.6 | 2026-03-15 | 資源タイプ語彙を JPCOAR 2.0 準拠に更新（#31） |
 | 1.3.5 | 2026-03-15 | 助成情報プログラム情報の表示順序修正（#34） |
@@ -28,6 +29,30 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 | 1.2.0 | 2026-03-13 | TSVエクスポート機能追加、残存issues優先順位整理 |
 | 1.1.0 | 2026-03-11 | OpenSearch検索タブ統合、JaLCデータ取込修正、書誌情報UI修正、入力モード自動判定 |
 | 1.0.0 | 2026-03-10 | 初期リリース（Manifest V3、Service Worker、OPFモーダル） |
+
+---
+
+## 2026-03-17: 助成情報検索ツールの課題番号抽出改善（#104）
+
+### 背景
+`extractAwardNumbers()` が入力を改行のみで分割し、スペースを含む行をAcknowledgementsテキストとみなして `/JP[A-Za-z0-9]+/g` だけで抽出していた。このため、セミコロン区切りの科研費課題番号リスト（例: `21H04856; 20K10467`）やAckテキスト中のJPプレフィックスなし科研費番号が抽出できなかった。
+
+### 変更内容
+
+1. **`extractAwardNumbers()` を3段階判定に改修**（`funder_lookup.html`, `chrome-extension/funder_lookup.js`）
+   - (A) スペースなし: そのまま1つの課題番号として扱う（従来通り）
+   - (B) セミコロン/カンマ区切りリスト判定: 全トークンが英数字のみなら個別の課題番号として分割
+   - (C) Acknowledgementsテキスト: JP付きパターンに加え、科研費パターン（`\d{2}[A-Z]{1,2}\d{4,5}`）も抽出
+
+2. **`KAKENHI_RE` 定数を追加**: `isKakenhi()` と同一パターンのAckテキスト抽出用正規表現
+
+3. **ヒントテキストを更新**: セミコロン・カンマ区切り対応の旨を追記（`funder_lookup.html`, `chrome-extension/funder_panel.html`）
+
+### 対象ファイル
+- `funder_lookup.html` — `extractAwardNumbers()` 改修、ヒントテキスト更新、LOCAL_VERSION更新
+- `chrome-extension/funder_lookup.js` — 同上のミラー
+- `chrome-extension/funder_panel.html` — ヒントテキスト・最終更新日更新
+- `chrome-extension/manifest.json` — version 1.3.7 → 1.3.8
 
 ---
 

--- a/funder_lookup.html
+++ b/funder_lookup.html
@@ -223,7 +223,7 @@
 <body>
 <h1>助成情報検索ツール</h1>
 <p style="font-size:0.82em; color:#555; margin:4px 0 12px;">
-  最終更新: 2026-03-13 &nbsp;|&nbsp;
+  最終更新: 2026-03-17 &nbsp;|&nbsp;
   <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#555;">github.com/tzhaya/jc-import-file-maker</a>
   <span id="update-check"></span>
 </p>
@@ -231,7 +231,7 @@
 <div class="input-section">
   <label for="award-input">課題番号またはAcknowledgementsテキストを入力してください。</label>
   <textarea id="award-input" placeholder="JP21H01234&#10;JPMJSA1907&#10;21K12345&#10;&#10;または謝辞テキストをそのまま貼り付け:&#10;This work was supported by JST CREST (Grant No. JPMJCR2125)."></textarea>
-  <div class="hint">課題番号（1行に1つ）またはAcknowledgementsテキストを貼り付けると、課題番号を自動で抽出します。科研費課題番号（JP付き / なし）や JGN 課題番号に対応しています。</div>
+  <div class="hint">課題番号（1行に1つ、またはセミコロン・カンマ区切り）やAcknowledgementsテキストを貼り付けると、課題番号を自動で抽出します。科研費課題番号（JP付き / なし）や JGN 課題番号に対応しています。</div>
   <button class="btn" id="search-btn" onclick="doSearch()">検索</button>
 </div>
 <div class="hint">
@@ -621,22 +621,42 @@ function buildResultCards(results) {
 // ===== 検索結果の保持（TSV出力用） =====
 let lastResults = [];
 
+// 科研費課題番号パターン（Ackテキスト抽出用、isKakenhi() と同一ルール）
+const KAKENHI_RE = /\b\d{2}[A-Z]{1,2}\d{4,5}\b/gi;
+
 // ===== 入力から課題番号を抽出（自動判定） =====
 function extractAwardNumbers(input) {
   const numbers = [];
   const seen = new Set();
+  const addUnique = (v) => { if (v && !seen.has(v)) { seen.add(v); numbers.push(v); } };
+
   for (const line of input.split(/\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    if (/\s/.test(trimmed)) {
-      // スペースを含む行: Acknowledgementsテキストとして JP... パターンを抽出
-      const matches = trimmed.match(/JP[A-Za-z0-9]+/g) || [];
-      for (const m of matches) {
-        if (!seen.has(m)) { seen.add(m); numbers.push(m); }
-      }
+
+    if (!/\s/.test(trimmed)) {
+      // (A) スペースなし: そのまま1つの課題番号
+      addUnique(trimmed);
+      continue;
+    }
+
+    // スペースを含む行 → 区切りリストか Ack テキストか判定
+    const tokens = trimmed.split(/[;,]/).map(t => t.trim()).filter(Boolean);
+    const allLookLikeIds = tokens.length > 1
+      && tokens.every(t => /^[A-Za-z0-9._-]+$/.test(t));
+
+    if (allLookLikeIds) {
+      // (B) セミコロン/カンマ区切りの課題番号リスト
+      for (const t of tokens) addUnique(t);
     } else {
-      // スペースなし: 課題番号として扱う
-      if (!seen.has(trimmed)) { seen.add(trimmed); numbers.push(trimmed); }
+      // (C) Acknowledgementsテキスト: JP... パターン + 科研費パターンを抽出
+      const jpMatches = trimmed.match(/JP[A-Za-z0-9]+/g) || [];
+      const kakenMatches = trimmed.match(KAKENHI_RE) || [];
+      for (const m of jpMatches) addUnique(m);
+      for (const m of kakenMatches) {
+        // JP付きで既に抽出済みなら重複スキップ（JP21H04856 と 21H04856）
+        if (!seen.has(m) && !seen.has('JP' + m)) addUnique(m);
+      }
     }
   }
   return numbers;
@@ -865,7 +885,7 @@ async function copyTsvToClipboard(btn) {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-03-13';
+  const LOCAL_VERSION = '2026-03-17';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=funder_lookup.html&per_page=1');
     if (!res.ok) return;


### PR DESCRIPTION
## Summary
- `extractAwardNumbers()` を3段階判定に改修し、セミコロン・カンマ区切りの課題番号リストを正しく分割できるようにした
- Acknowledgementsテキストから科研費番号（JPプレフィックスなし、例: `21H04856`）も抽出できるようにした
- `KAKENHI_RE` 定数を追加（`isKakenhi()` と同一パターン）

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `funder_lookup.html` | `extractAwardNumbers()` 改修、ヒント更新、LOCAL_VERSION・最終更新日更新 |
| `chrome-extension/funder_lookup.js` | 同上のミラー |
| `chrome-extension/funder_panel.html` | ヒント・最終更新日更新 |
| `chrome-extension/manifest.json` | version 1.3.7 → 1.3.8 |
| `README.md` | 最新の更新テーブル・変更履歴追記 |
| `docs/worklog.md` | バージョン履歴・詳細セクション追記 |

## Test plan
- [x] E2E テスト（main）: DOI `10.1038/s41467-023-40773-1` — ALL PASSED
- [x] E2E テスト（funder）: `JP16K07412` — ALL PASSED
- [x] E2E テスト（funder）: `JPMJSA1907` — ALL PASSED
- [x] セミコロン区切り入力: `21H04856; 20K10467; 20K19633` → 3件抽出
- [x] Ackテキスト（Issue #104 の本文）→ 科研費10件 + JST 1件 抽出

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)