### PR TITLE
fix: Chrome拡張TSV出力ボタンのCSPエラーを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Chrome拡張版と通常ブラウザ版の2つの利用方法があります。
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張版 | 2026-03-17 | ver. 1.3.8 | 助成情報検索ツールの課題番号抽出を改善：セミコロン・カンマ区切り入力対応、Ackテキストから科研費番号を抽出（[#104](https://github.com/tzhaya/jc-import-file-maker/issues/104)） |
+| Chrome拡張版 | 2026-03-17 | ver. 1.3.9 | Chrome拡張でTSV出力ボタンのCSPエラーを修正（[#103](https://github.com/tzhaya/jc-import-file-maker/issues/103)） |
 | インポート用TSV生成ツール | 2026-03-15 | — | JPCOARスキーマ説明リンクを2.0に更新、下位項目にもスキーマリンクを追加（[#87](https://github.com/tzhaya/jc-import-file-maker/issues/87)） |
 | 助成情報検索ツール | 2026-03-17 | — | 課題番号抽出を改善：セミコロン・カンマ区切り入力対応、Ackテキストから科研費番号を抽出（[#104](https://github.com/tzhaya/jc-import-file-maker/issues/104)） |
 
@@ -256,6 +256,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-17 | Chrome拡張でTSV出力ボタンがCSPエラーで動作しない不具合を修正：インラインイベントハンドラをaddEventListenerに置換（[#103](https://github.com/tzhaya/jc-import-file-maker/issues/103)） |
 | 2026-03-17 | 助成情報検索ツールの課題番号抽出を改善：セミコロン・カンマ区切り入力対応、Acknowledgementsテキストから科研費番号（JPプレフィックスなし）を抽出（[#104](https://github.com/tzhaya/jc-import-file-maker/issues/104)） |
 | 2026-03-15 | JPCOARスキーマ説明リンクを2.0に更新、下位項目（著者・助成情報・関連情報等）にもスキーマリンクを追加、JPCOARschema_guide.md を1.0.2/2.0併記に更新（[#87](https://github.com/tzhaya/jc-import-file-maker/issues/87)） |
 | 2026-03-15 | 資源タイプ語彙を JPCOAR 2.0 準拠に更新：TITLE_MAPS.resourcetype から v1.0 廃止語彙（internal report・report part）を削除、CROSSREF_TYPE_MAP の report-component マッピング修正、getDoiCategory() に v2.0 新タイプ追加（[#31](https://github.com/tzhaya/jc-import-file-maker/issues/31)） |

--- a/chrome-extension/funder_panel.html
+++ b/chrome-extension/funder_panel.html
@@ -7,16 +7,14 @@
 <style>
   .ext-nav { display:flex; gap:0; margin-bottom:12px; border-bottom:2px solid #c8e6c9; }
   .ext-nav a { padding:6px 16px; text-decoration:none; font-size:0.9em; color:#555; border:1px solid transparent; border-bottom:none; border-radius:4px 4px 0 0; }
-  .ext-nav a.active { background:#fff; color:#1b5e20; font-weight:bold; border-color:#c8e6c9; margin-bottom:-2px; }
+  .ext-nav a.active { background:#fff; color:#2c5f2e; font-weight:bold; border-color:#c8e6c9; margin-bottom:-2px; }
   .ext-nav a:hover:not(.active) { background:#e8f5e9; }
   body {
-    font-family: 'Segoe UI', 'Hiragino Sans', 'Meiryo', sans-serif;
+    font-family: sans-serif;
     font-size: 14px;
-    max-width: 960px;
-    margin: 20px auto;
-    padding: 0 20px;
+    margin: 20px;
     color: #333;
-    background: #fafafa;
+    background: #f5f5f5;
   }
   h1 {
     font-size: 1.4em;

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -5192,6 +5192,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 document.getElementById('fetch-btn').addEventListener('click', fetchData);
 document.getElementById('empty-btn').addEventListener('click', showEmptyFields);
 document.getElementById('preview-btn').addEventListener('click', showPreview);
+document.getElementById('export-btn').addEventListener('click', exportTsv);
 document.getElementById('opf-badge').addEventListener('click', openOpfModal);
 document.getElementById('opf-modal').addEventListener('click', (e) => {
   if (e.target === e.currentTarget) closeOpfModal();

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "DOIからJAIRO Cloud インポート用TSVを生成するツール。CORS非対応APIへのアクセスとAPIキー管理を提供します。",
   "permissions": ["storage", "sidePanel"],
   "host_permissions": [

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -512,7 +512,7 @@
     <button id="fetch-btn">データ取得</button>
     <button id="empty-btn">空値で全フィールド表示</button>
     <button id="preview-btn" style="display:none; background:#1565c0; color:white;">プレビュー表示</button>
-    <button id="export-btn" onclick="exportTsv()" style="display:none; background:#2e7d32; color:white;">TSV出力</button>
+    <button id="export-btn" style="display:none; background:#2e7d32; color:white;">TSV出力</button>
   </div>
   <details id="tsv-options" style="display:none; margin-top:6px; font-size:0.9em;">
     <summary style="cursor:pointer; color:#555; user-select:none;">TSV出力オプション（プロパティキーのカスタマイズ）</summary>

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-17（助成情報検索ツールの課題番号抽出改善 #104）
+最終更新: 2026-03-17（Chrome拡張TSV出力CSPエラー修正 #103）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -16,6 +16,7 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.3.9 | 2026-03-17 | Chrome拡張TSV出力ボタンのCSPエラー修正（#103） |
 | 1.3.8 | 2026-03-17 | 助成情報検索ツールの課題番号抽出改善：セミコロン・カンマ区切り入力対応、Ackテキストから科研費番号抽出（#104） |
 | 1.3.7 | 2026-03-15 | JPCOARスキーマ説明リンクを2.0に更新、下位項目にもスキーマリンクを追加（#87） |
 | 1.3.6 | 2026-03-15 | 資源タイプ語彙を JPCOAR 2.0 準拠に更新（#31） |
@@ -29,6 +30,18 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 | 1.2.0 | 2026-03-13 | TSVエクスポート機能追加、残存issues優先順位整理 |
 | 1.1.0 | 2026-03-11 | OpenSearch検索タブ統合、JaLCデータ取込修正、書誌情報UI修正、入力モード自動判定 |
 | 1.0.0 | 2026-03-10 | 初期リリース（Manifest V3、Service Worker、OPFモーダル） |
+
+---
+
+## 2026-03-17: Chrome拡張TSV出力ボタンのCSPエラー修正（#103）
+
+### 背景
+Chrome拡張 Manifest V3 のデフォルト CSP (`script-src 'self'`) により、`panel.html` の TSV出力ボタンに設定されたインラインイベントハンドラ (`onclick="exportTsv()"`) がブロックされ、TSV出力が機能しなかった。他の3ボタン（fetch/empty/preview）は既に `addEventListener` に移行済みだったが、export-btn のみ対応漏れしていた。
+
+### 変更内容
+
+1. **`chrome-extension/panel.html`**: `<button id="export-btn">` から `onclick="exportTsv()"` を削除
+2. **`chrome-extension/make_jc_importer.js`**: イベントリスナー登録ブロックに `document.getElementById('export-btn').addEventListener('click', exportTsv)` を追加
 
 ---
 


### PR DESCRIPTION
## Summary
- Chrome拡張の TSV出力ボタン (`panel.html`) のインラインイベントハンドラ (`onclick="exportTsv()"`) を `addEventListener` に置換し、Manifest V3 の CSP (`script-src 'self'`) 違反を解消
- `funder_panel.html` の `body` スタイル（`max-width`, `margin`, `font-family`, `background`）とアクティブタブ色を他パネル (`panel.html`, `opensearch_panel.html`) と統一し、タブ切り替え時のレイアウトずれを修正

Closes #103

## Test plan
- [x] Chrome拡張リロード → DOI入力 → データ取得 → TSV出力ボタンクリック → TSVダウンロード成功確認
- [x] DevTools Console に CSP エラーが出ないことを確認
- [x] タブ切り替え（DOIインポート ↔ 助成情報検索 ↔ OpenSearch検索）でレイアウトがずれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)