### PR TITLE
fix: OA Status=closed時のエンバーゴアクセス権修正 (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張機能版 | 2026-03-22 | ver. 1.8.1 | OA情報統合：OAステータス全6値対応、出版タイプ・アクセス権のOAステータス連動自動設定、OPFモーダル連動表示（[#51](https://github.com/tzhaya/jc-import-file-maker/issues/51)） |
-| インポート用TSV生成ツール | 2026-03-22 | — | OA情報統合 + UIラベル日本語化（[#51](https://github.com/tzhaya/jc-import-file-maker/issues/51)） |
+| Chrome拡張機能版 | 2026-03-23 | ver. 1.8.2 | エンバーゴアクセス権修正：OA Status=closed時のアクセス権をOPFエンバーゴ情報に基づき自動設定（[#51](https://github.com/tzhaya/jc-import-file-maker/issues/51)） |
+| インポート用TSV生成ツール | 2026-03-23 | — | エンバーゴアクセス権修正：OPF取得タイミング修正、JaLCパスのアクセス権動的化（[#51](https://github.com/tzhaya/jc-import-file-maker/issues/51)） |
 | 助成情報検索ツール | 2026-03-17 | — | 課題番号抽出を改善：セミコロン・カンマ区切り入力対応、Ackテキストから科研費番号を抽出（[#104](https://github.com/tzhaya/jc-import-file-maker/issues/104)） |
 
 ## 導入方法
@@ -250,6 +250,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-03-23 | エンバーゴアクセス権修正：OA Status=closed時のアクセス権をOPFエンバーゴ情報に基づきembargoed accessに自動設定、OPF取得タイミング修正（mapToItemType前に移動）、JaLCパスのアクセス権動的化（[#51](https://github.com/tzhaya/jc-import-file-maker/issues/51)） |
 | 2026-03-22 | OA情報統合 + UIラベル日本語化：OAステータス全6値対応（diamond/bronze追加）、出版タイプ・relationType・アクセス権のOAステータス連動自動設定、OpenAlexリポジトリ情報取得、OPFモーダル連動表示、エンバーゴヒント表示（[#51](https://github.com/tzhaya/jc-import-file-maker/issues/51)） |
 | 2026-03-22 | 複数DOI一括TSV出力（Phase 2-C）：DOIを連続取得して蓄積し、ヘッダー5行+データN行の一括TSVを出力。バッチ管理パネル（蓄積件数表示・個別削除・全クリア・アイテム切替）、リポジトリURL入力でスキーマURL置換、タイムスタンプベースファイル名（[#100](https://github.com/tzhaya/jc-import-file-maker/issues/100)） |
 | 2026-03-22 | カスタムテンプレート完全パース対応（Phase 2-B）：5行ヘッダー貼り付けでTSVテンプレートを丸ごと上書き、ItemType行の自動設定（Phase 2-D）（[#99](https://github.com/tzhaya/jc-import-file-maker/issues/99), [#101](https://github.com/tzhaya/jc-import-file-maker/issues/101)） |

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -342,12 +342,15 @@ function determineAccessRights(oaStatus, opfData) {
   if (['diamond', 'gold', 'hybrid', 'bronze', 'green'].includes(oaStatus)) {
     return 'open access';
   }
-  if (oaStatus === 'closed' && opfData?.items?.[0]) {
+  // Closed / Unknown → OPFエンバーゴの有無で判定
+  // （open系5種は上で早期リターン済み。ここに到達するのは closed か OAステータス不明のみ）
+  if (opfData?.items?.[0]) {
     const hasEmbargo = (opfData.items[0].publisher_policy || []).some(p =>
       (p.permitted_oa || []).some(oa => oa.embargo?.amount > 0)
     );
     if (hasEmbargo) return 'embargoed access';
   }
+  // エンバーゴなし / OPFデータなし → open access（機関リポジトリ登録用途を想定）
   return 'open access';
 }
 
@@ -1118,7 +1121,28 @@ async function fetchOpenPolicyFinder(issns) {
   return null;
 }
 
-// ===== 3.5.3 OPF ステータス更新・モーダル制御 =====
+// ===== 3.5.3 ISSN早期抽出（生APIレスポンスから） =====
+function extractIssnsFromRaw(crJson, jalcJson) {
+  const issns = [];
+  if (crJson) {
+    const issnType = crJson['issn-type'] || [];
+    if (issnType.length) {
+      issnType.forEach(i => issns.push(i.value));
+    } else {
+      (crJson.ISSN || []).forEach(i => issns.push(i));
+    }
+  }
+  if (jalcJson) {
+    (jalcJson.journal_id_list || []).forEach(j => {
+      if ((j.type || '').toUpperCase() === 'ISSN' && j.journal_id) {
+        issns.push(j.journal_id);
+      }
+    });
+  }
+  return issns;
+}
+
+// ===== 3.5.4 OPF ステータス更新・モーダル制御 =====
 async function updateOpfStatus(issns) {
   const badge = document.getElementById('opf-badge');
   const summary = document.getElementById('opf-summary');
@@ -1322,9 +1346,6 @@ async function fetchCrossrefData(doi) {
     fetchOpenAlex(doi),
   ]);
 
-  // ROR データを並列取得
-  const rorMap = await fetchAllRorData(oaJson);
-
   // 情報バー表示
   const doiUrl = `https://doi.org/${doi}`;
   const doiLink = document.getElementById('doi-link');
@@ -1340,10 +1361,17 @@ async function fetchCrossrefData(doi) {
   badge.style.background = badgeInfo.bg;
   document.getElementById('info-bar').style.display = 'flex';
 
-  // マッピング → レンダリング
+  // ISSN早期抽出 → ROR + OPF を並列取得（OPFはmapToItemType前に必要）
+  const earlyIssns = extractIssnsFromRaw(crJson, null);
+  const [rorMap] = await Promise.all([
+    fetchAllRorData(oaJson),
+    updateOpfStatus(earlyIssns),
+  ]);
+
+  // マッピング → レンダリング（lastOpfData が設定済みの状態で実行）
   const metadata = await mapToItemType(crJson, oaJson, rorMap);
 
-  // ISSN抽出
+  // ISSN抽出（メタデータから、OPF参照リンク用）
   const issns = (metadata.item_30002_source_identifier22 || [])
     .filter(si => ['ISSN','PISSN','EISSN'].includes(si.subitem_source_identifier_type))
     .map(si => si.subitem_source_identifier);
@@ -1358,9 +1386,6 @@ async function fetchCrossrefData(doi) {
   } else {
     opfRow.style.display = 'none';
   }
-
-  // OPF API 連携（Chrome拡張 + OPF_API_KEY 設定時のみ）
-  await updateOpfStatus(issns);
 
   showHints = true;
   renderAll(metadata);
@@ -1383,16 +1408,15 @@ async function fetchJaLCData(doi) {
   const badge = document.getElementById('oa-badge');
   badge.textContent = '⚪ Unknown';
   badge.style.background = '#999';
+  lastOaStatus = '';
   document.getElementById('info-bar').style.display = 'flex';
 
-  // マッピング → レンダリング
-  const metadata = await mapToItemTypeJaLC(jalcJson);
+  // ISSN早期抽出 → OPF取得（mapToItemTypeJaLC前に必要）
+  const earlyIssns = extractIssnsFromRaw(null, jalcJson);
+  await updateOpfStatus(earlyIssns);
 
-  // ISSN抽出 + OPF API 連携
-  const issns = (metadata.item_30002_source_identifier22 || [])
-    .filter(si => ['ISSN','PISSN','EISSN'].includes(si.subitem_source_identifier_type))
-    .map(si => si.subitem_source_identifier);
-  await updateOpfStatus(issns);
+  // マッピング → レンダリング（lastOpfData が設定済みの状態で実行）
+  const metadata = await mapToItemTypeJaLC(jalcJson);
 
   showHints = true;
   renderAll(metadata);
@@ -2472,6 +2496,10 @@ async function mapToItemTypeJaLC(jalcJson) {
     ? VERSION_TYPE_MAP['AO']
     : VERSION_TYPE_MAP['VoR'];
 
+  // ===== アクセス権（OPFエンバーゴ連動） =====
+  const accessRight    = determineAccessRights(lastOaStatus, lastOpfData);
+  const accessRightUri = ACCESS_RIGHTS_MAP[accessRight] || ACCESS_RIGHTS_MAP['open access'];
+
   // ===== メタデータオブジェクト =====
   const metadata = {
     system: {
@@ -2487,8 +2515,8 @@ async function mapToItemTypeJaLC(jalcJson) {
     item_30002_contributor3: [],
 
     item_30002_access_rights4: {
-      subitem_access_right:     'open access',
-      subitem_access_right_uri: 'http://purl.org/coar/access_right/c_abf2',
+      subitem_access_right:     accessRight,
+      subitem_access_right_uri: accessRightUri,
     },
 
     item_30002_rights6: rights,
@@ -5976,7 +6004,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-03-22';
+  const LOCAL_VERSION = '2026-03-23';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "DOIからJAIRO Cloud インポート用TSVを生成するツール。CORS非対応APIへのアクセスとAPIキー管理を提供します。",
   "permissions": ["storage", "sidePanel"],
   "host_permissions": [

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -500,7 +500,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-03-22 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-03-23 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -512,6 +512,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-23</td>
+        <td style="padding:2px 0;">エンバーゴアクセス権修正：OA Status=closed時のアクセス権をOPFエンバーゴ情報に基づき自動設定、OPF取得タイミング修正（#51）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-22</td>
         <td style="padding:2px 0;">OA情報統合：OAステータス全6値対応、出版タイプ/relationType/アクセス権の自動設定、リポジトリ情報取得、OPFモーダル連動、エンバーゴヒント表示（#51）</td>
@@ -527,10 +531,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-22</td>
         <td style="padding:2px 0;">ファイル情報のパス自動判定：data/以下のフォルダ選択でfile_pathを自動設定、PDF→fulltext/画像→thumbnail自動判別（#90）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-21</td>
-        <td style="padding:2px 0;">TSVヘッダーテンプレートを更新：tsv_headers.jsonとTSV_HEADERS_TEMPLATEを同期、.thumbnail_pathシステムフィールド追加（226→232列）（#114）</td>
       </tr>
     </tbody>
   </table>

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -161,11 +161,11 @@ make_jc_importer.html
         -   green: AAM + isVersionOf（著者最終稿）
         -   bronze/closed: VoR + isIdenticalTo（出版者版、アクセス制限あり）
     -   **アクセス権の動的設定**（`determineAccessRights()`関数）:
-        -   OAステータスに基づいてアクセス権を自動設定する
-        -   open access: diamond/gold/hybrid/green（即時OA）
-        -   restricted access: bronze（制限付きOA）
-        -   metadata only access: closed（本文非公開）
-        -   embargoed access: closed かつ OpenAlex の best_oa_location にエンバーゴ日付がある場合
+        -   OAステータスとOPFエンバーゴ情報に基づいてアクセス権を自動設定する
+        -   open access: diamond/gold/hybrid/bronze/green（OA系ステータス）
+        -   embargoed access: closed/unknown かつ OPFにエンバーゴ情報がある場合
+        -   open access（デフォルト）: closed/unknown でエンバーゴなし（機関リポジトリ登録用途を想定）
+        -   OPFデータはmapToItemType/mapToItemTypeJaLCの前に取得される（ISSN早期抽出による）
     -   **OpenAlexリポジトリ情報の関連情報追加**:
         -   OpenAlex の `any_repository_has_fulltext` が true の場合、`locations[]` からリポジトリ（source.type = "repository"）の landing_page_url を抽出し、関連情報（relationType: isIdenticalTo, identifierType: URI）として追加する
     -   **OPFモーダルのOAステータス連動**:
@@ -350,12 +350,11 @@ make_jc_importer.html
 - **アクセス権の設定**
     - アクセス権（"key": "item_30002_access_rights4"）は以下のように設定します。
         - アクセス権（"key": "item_30002_access_rights4.subitem_access_right"）
-            - OpenAlexのOAステータスに基づき `determineAccessRights()` で動的に設定（[#51](https://github.com/tzhaya/jc-import-file-maker/issues/51)）
-            - diamond/gold/hybrid/green: "open access"
-            - bronze: "restricted access"
-            - closed（エンバーゴあり）: "embargoed access"
-            - closed（エンバーゴなし）: "metadata only access"
-            - OpenAlex未取得時のデフォルト: "open access"
+            - OAステータスとOPFエンバーゴ情報に基づき `determineAccessRights()` で動的に設定（[#51](https://github.com/tzhaya/jc-import-file-maker/issues/51)）
+            - diamond/gold/hybrid/bronze/green: "open access"
+            - closed/unknown + OPFエンバーゴあり: "embargoed access"
+            - closed/unknown + エンバーゴなし/OPFデータなし: "open access"（機関リポジトリ登録用途を想定）
+            - JaLCパスでも `determineAccessRights()` を使用（OAステータスは空文字）
         - アクセス権URI（"key": "item_30002_access_rights4.subitem_access_right_uri"）
             - アクセス権の値に応じて `ACCESS_RIGHTS_MAP` から自動設定
 

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-03-22（OA情報統合 + UIラベル日本語化 #51）
+最終更新: 2026-03-23（エンバーゴアクセス権修正 #51）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -16,6 +16,7 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.8.2 | 2026-03-23 | エンバーゴアクセス権修正：OPF取得タイミング修正、JaLCパスのアクセス権動的化（#51） |
 | 1.8.1 | 2026-03-22 | OA情報統合 + UIラベル日本語化：OAステータス全6値対応、出版タイプ・アクセス権連動、OPFモーダル連動、エンバーゴヒント表示（#51） |
 | 1.8.0 | 2026-03-22 | 複数DOI一括TSV出力（Phase 2-C）：バッチ蓄積・一括エクスポート、リポジトリURL入力、タイムスタンプファイル名（#100） |
 | 1.7.0 | 2026-03-22 | カスタムテンプレート完全パース対応（Phase 2-B）、ItemType行自動設定（Phase 2-D）（#99, #101） |
@@ -39,6 +40,30 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 | 1.2.0 | 2026-03-13 | TSVエクスポート機能追加、残存issues優先順位整理 |
 | 1.1.0 | 2026-03-11 | OpenSearch検索タブ統合、JaLCデータ取込修正、書誌情報UI修正、入力モード自動判定 |
 | 1.0.0 | 2026-03-10 | 初期リリース（Manifest V3、Service Worker、OPFモーダル） |
+
+---
+
+## 2026-03-23: エンバーゴアクセス権修正（#51）
+
+### 概要
+OA Status=closed時のアクセス権を「embargoed access」に自動設定する機能が、OPFデータ取得タイミングの問題で機能していなかったバグを修正。
+
+### 根本原因
+- `fetchCrossrefData()`で`mapToItemType()`が`updateOpfStatus()`より前に実行されるため、`determineAccessRights()`呼び出し時に`lastOpfData`が常にnull
+- `mapToItemTypeJaLC()`ではアクセス権が`'open access'`にハードコードされ、`determineAccessRights()`を使用していなかった
+
+### 実装内容
+- `extractIssnsFromRaw()`: 生APIレスポンスからISSNを早期抽出するヘルパー関数を追加
+- `fetchCrossrefData()`: ROR + OPF並列取得を`mapToItemType()`の前に移動
+- `fetchJaLCData()`: OPF取得を`mapToItemTypeJaLC()`の前に移動、`lastOaStatus`を明示設定
+- `mapToItemTypeJaLC()`: ハードコード`'open access'`を`determineAccessRights()`呼び出しに変更
+- `determineAccessRights()`: `oaStatus === 'closed'`条件を緩和（open系以外すべてチェック）
+
+### 変更ファイル
+- `make_jc_importer.html` — コアロジック5箇所変更
+- `chrome-extension/make_jc_importer.js` — 同一変更の同期
+- `chrome-extension/panel.html` — 更新概要テーブル更新
+- `chrome-extension/manifest.json` — 1.8.1→1.8.2
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -490,7 +490,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-03-22 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-03-23 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -502,6 +502,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-23</td>
+        <td style="padding:2px 0;">エンバーゴアクセス権修正：OA Status=closed時のアクセス権をOPFエンバーゴ情報に基づき自動設定、OPF取得タイミング修正（#51）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-22</td>
         <td style="padding:2px 0;">OA情報統合：OAステータス全6値対応、出版タイプ/relationType/アクセス権の自動設定、リポジトリ情報取得、OPFモーダル連動、エンバーゴヒント表示（#51）</td>
@@ -517,10 +521,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-22</td>
         <td style="padding:2px 0;">ファイル情報のパス自動判定：data/以下のフォルダ選択でfile_pathを自動設定、PDF→fulltext/画像→thumbnail自動判別（#90）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-21</td>
-        <td style="padding:2px 0;">TSVヘッダーテンプレートを更新：tsv_headers.jsonとTSV_HEADERS_TEMPLATEを同期、.thumbnail_pathシステムフィールド追加（226→232列）（#114）</td>
       </tr>
     </tbody>
   </table>
@@ -986,14 +986,15 @@ function determineAccessRights(oaStatus, opfData) {
   if (['diamond', 'gold', 'hybrid', 'bronze', 'green'].includes(oaStatus)) {
     return 'open access';
   }
-  // Closed → OPFエンバーゴの有無で判定
-  if (oaStatus === 'closed' && opfData?.items?.[0]) {
+  // Closed / Unknown → OPFエンバーゴの有無で判定
+  // （open系5種は上で早期リターン済み。ここに到達するのは closed か OAステータス不明のみ）
+  if (opfData?.items?.[0]) {
     const hasEmbargo = (opfData.items[0].publisher_policy || []).some(p =>
       (p.permitted_oa || []).some(oa => oa.embargo?.amount > 0)
     );
     if (hasEmbargo) return 'embargoed access';
   }
-  // Closed（エンバーゴなし）/ その他 → open access（機関リポジトリ登録用途を想定）
+  // エンバーゴなし / OPFデータなし → open access（機関リポジトリ登録用途を想定）
   return 'open access';
 }
 
@@ -1764,7 +1765,28 @@ async function fetchOpenPolicyFinder(issns) {
   return null;
 }
 
-// ===== 3.5.3 OPF ステータス更新・モーダル制御 =====
+// ===== 3.5.3 ISSN早期抽出（生APIレスポンスから） =====
+function extractIssnsFromRaw(crJson, jalcJson) {
+  const issns = [];
+  if (crJson) {
+    const issnType = crJson['issn-type'] || [];
+    if (issnType.length) {
+      issnType.forEach(i => issns.push(i.value));
+    } else {
+      (crJson.ISSN || []).forEach(i => issns.push(i));
+    }
+  }
+  if (jalcJson) {
+    (jalcJson.journal_id_list || []).forEach(j => {
+      if ((j.type || '').toUpperCase() === 'ISSN' && j.journal_id) {
+        issns.push(j.journal_id);
+      }
+    });
+  }
+  return issns;
+}
+
+// ===== 3.5.4 OPF ステータス更新・モーダル制御 =====
 async function updateOpfStatus(issns) {
   const badge = document.getElementById('opf-badge');
   const summary = document.getElementById('opf-summary');
@@ -1969,9 +1991,6 @@ async function fetchCrossrefData(doi) {
     fetchOpenAlex(doi),
   ]);
 
-  // ROR データを並列取得
-  const rorMap = await fetchAllRorData(oaJson);
-
   // 情報バー表示
   const doiUrl = `https://doi.org/${doi}`;
   const doiLink = document.getElementById('doi-link');
@@ -1987,10 +2006,17 @@ async function fetchCrossrefData(doi) {
   badge.style.background = badgeInfo.bg;
   document.getElementById('info-bar').style.display = 'flex';
 
-  // マッピング → レンダリング
+  // ISSN早期抽出 → ROR + OPF を並列取得（OPFはmapToItemType前に必要）
+  const earlyIssns = extractIssnsFromRaw(crJson, null);
+  const [rorMap] = await Promise.all([
+    fetchAllRorData(oaJson),
+    updateOpfStatus(earlyIssns),
+  ]);
+
+  // マッピング → レンダリング（lastOpfData が設定済みの状態で実行）
   const metadata = await mapToItemType(crJson, oaJson, rorMap);
 
-  // ISSN抽出
+  // ISSN抽出（メタデータから、OPF参照リンク用）
   const issns = (metadata.item_30002_source_identifier22 || [])
     .filter(si => ['ISSN','PISSN','EISSN'].includes(si.subitem_source_identifier_type))
     .map(si => si.subitem_source_identifier);
@@ -2005,9 +2031,6 @@ async function fetchCrossrefData(doi) {
   } else {
     opfRow.style.display = 'none';
   }
-
-  // OPF API 連携（Chrome拡張 + OPF_API_KEY 設定時のみ）
-  await updateOpfStatus(issns);
 
   showHints = true;
   renderAll(metadata);
@@ -2030,16 +2053,15 @@ async function fetchJaLCData(doi) {
   const badge = document.getElementById('oa-badge');
   badge.textContent = '⚪ Unknown';
   badge.style.background = '#999';
+  lastOaStatus = '';
   document.getElementById('info-bar').style.display = 'flex';
 
-  // マッピング → レンダリング
-  const metadata = await mapToItemTypeJaLC(jalcJson);
+  // ISSN早期抽出 → OPF取得（mapToItemTypeJaLC前に必要）
+  const earlyIssns = extractIssnsFromRaw(null, jalcJson);
+  await updateOpfStatus(earlyIssns);
 
-  // ISSN抽出 + OPF API 連携
-  const issns = (metadata.item_30002_source_identifier22 || [])
-    .filter(si => ['ISSN','PISSN','EISSN'].includes(si.subitem_source_identifier_type))
-    .map(si => si.subitem_source_identifier);
-  await updateOpfStatus(issns);
+  // マッピング → レンダリング（lastOpfData が設定済みの状態で実行）
+  const metadata = await mapToItemTypeJaLC(jalcJson);
 
   showHints = true;
   renderAll(metadata);
@@ -3119,6 +3141,10 @@ async function mapToItemTypeJaLC(jalcJson) {
     ? VERSION_TYPE_MAP['AO']
     : VERSION_TYPE_MAP['VoR'];
 
+  // ===== アクセス権（OPFエンバーゴ連動） =====
+  const accessRight    = determineAccessRights(lastOaStatus, lastOpfData);
+  const accessRightUri = ACCESS_RIGHTS_MAP[accessRight] || ACCESS_RIGHTS_MAP['open access'];
+
   // ===== メタデータオブジェクト =====
   const metadata = {
     system: {
@@ -3134,8 +3160,8 @@ async function mapToItemTypeJaLC(jalcJson) {
     item_30002_contributor3: [],
 
     item_30002_access_rights4: {
-      subitem_access_right:     'open access',
-      subitem_access_right_uri: 'http://purl.org/coar/access_right/c_abf2',
+      subitem_access_right:     accessRight,
+      subitem_access_right_uri: accessRightUri,
     },
 
     item_30002_rights6: rights,
@@ -6623,7 +6649,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-03-22';
+  const LOCAL_VERSION = '2026-03-23';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;


### PR DESCRIPTION
## Summary
- OA Status=closed時に`determineAccessRights()`がOPFエンバーゴ情報に基づき「embargoed access」を設定する機能が、OPFデータ取得タイミングの問題で機能していなかったバグを修正
- `fetchCrossrefData()`でISSN早期抽出→ROR+OPF並列取得の順序に変更し、`mapToItemType()`前にOPFデータを確保
- JaLCパスのアクセス権もハードコード`'open access'`から`determineAccessRights()`による動的設定に変更

## 変更内容
| ファイル | 変更内容 |
|---------|---------|
| `make_jc_importer.html` | `extractIssnsFromRaw()`追加、`fetchCrossrefData()`/`fetchJaLCData()`のOPF取得タイミング修正、`mapToItemTypeJaLC()`のアクセス権動的化、`determineAccessRights()`のスコープ拡大 |
| `chrome-extension/make_jc_importer.js` | 同一変更の同期 |
| `chrome-extension/panel.html` | 更新概要テーブル更新 |
| `chrome-extension/manifest.json` | 1.8.1→1.8.2 |
| `README.md` | 最新の更新・変更履歴追記 |
| `docs/requirements.md` | アクセス権設定の要件をOPFベースに更新 |
| `docs/worklog.md` | 作業ログ追記 |

## 根本原因
`fetchCrossrefData()`内で`mapToItemType()`（L1991）が`updateOpfStatus()`（L2010）より**前に**実行されていたため、`determineAccessRights(oaStatus, lastOpfData)`の`lastOpfData`が常にnullだった。

## 動作確認
- `10.1093/pcp/pcaf136`（OA Status: closed）でアクセス権が「embargoed access」に設定されることを確認済み
- E2E テスト ALL PASSED（main + funder）

## Test plan
- [x] OA Status=closedの文献（`10.1093/pcp/pcaf136`）でアクセス権が「embargoed access」になること
- [x] OA Status=green/gold等の文献でアクセス権が「open access」のまま（既存動作に影響なし）
- [x] E2Eテスト ALL PASSED
- [x] Chrome拡張版での動作確認

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)