### PR TITLE
chore: ツール名を「JAIRO Cloud インポート支援ツール」に統一

### DIFF
--- a/chrome-extension/options.html
+++ b/chrome-extension/options.html
@@ -2,7 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <title>JAIRO Cloud インポートツール — 設定</title>
+  <title>JAIRO Cloud インポート支援ツール — 設定</title>
   <style>
     body {
       font-family: sans-serif;

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>JAIRO Cloud インポート用TSV生成ツール</title>
+<title>JAIRO Cloud インポート支援ツール</title>
 <style>
   /* ===== ナビゲーション ===== */
   .ext-nav { display:flex; gap:0; margin-bottom:12px; border-bottom:2px solid #c8e6c9; }
@@ -492,7 +492,7 @@
   <a href="funder_panel.html">助成情報検索</a>
   <a href="opensearch_panel.html">OpenSearch検索</a>
 </nav>
-<h1>🌾 JAIRO Cloud インポート用TSV生成ツール(β)</h1>
+<h1>🌾 JAIRO Cloud インポート支援ツール</h1>
 
 <p>このツールはベータ版です。「デフォルトアイテムタイプ（フル）」の形式でTSVファイルを出力できます。</p>
 <p>現在のバージョンでは、Crossref APIおよびOpenAlex APIからのデータ取得が実装されています。Chrome拡張では、JaLC DOIにも対応しています。</p>

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>JAIRO Cloud インポート用TSV生成ツール</title>
+<title>JAIRO Cloud インポート支援ツール</title>
 <style>
   /* ===== ベーススタイル ===== */
   body { font-family: sans-serif; margin: 20px; background: #f5f5f5; }


### PR DESCRIPTION
## Summary
- Chrome ウェブストアで公開した名称と HTML 上のページタイトル / ヘディングを統一
- `panel.html` の `<title>` / `<h1>`、`options.html` の `<title>`、`make_jc_importer.html` の `<title>` を旧名「JAIRO Cloud インポート用TSV生成ツール」から新名「JAIRO Cloud インポート支援ツール」に変更
- 利用者がブラウザのタブやサイドパネル見出しでストアと同一の名称を確認できる

## Test plan
- [x] 拡張機能を読み込み、サイドパネルのタブ見出し（パネル `<h1>`）が「JAIRO Cloud インポート支援ツール」になっていることを確認
- [x] オプションページのブラウザタブが「JAIRO Cloud インポート支援ツール — 設定」になっていることを確認
- [x] `make_jc_importer.html` を直接ブラウザで開き、タブ名が「JAIRO Cloud インポート支援ツール」になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)