### PR TITLE
chore: Chrome拡張 ver. 1.9.3 — ストア再配布用 manifest version 更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張機能版 | 2026-05-13 | ver. 1.9.2 | Chromeウェブストア登録準備：拡張機能アイコン（16/48/128）追加、プライバシーポリシー策定、manifest.jsonにiconsとaction.default_iconを設定（[#112](https://github.com/tzhaya/jc-import-file-maker/issues/112)） |
+| Chrome拡張機能版 | 2026-05-14 | ver. 1.9.3 | Chromeウェブストア公開名と一致するようツール名・タイトルを「JAIRO Cloud インポート支援ツール」に統一、ストア再配布用にmanifest版数を更新 |
 | インポート用TSV生成ツール | 2026-03-29 | — | shared.js未配置時のフォールバック：警告表示+APIキーなしで動作継続（[#111](https://github.com/tzhaya/jc-import-file-maker/issues/111)） |
 | 助成情報検索ツール | 2026-03-29 | — | shared.js未配置時のフォールバック：警告表示+APIキーなしで動作継続（[#111](https://github.com/tzhaya/jc-import-file-maker/issues/111)） |
 
@@ -276,6 +276,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-05-14 | Chrome拡張機能 ver. 1.9.3：Chromeウェブストア公開名と一致するようツール名・タイトルを「JAIRO Cloud インポート支援ツール」に統一（`panel.html` / `options.html` / `make_jc_importer.html`）、ストア再配布用に manifest version を `1.9.2` → `1.9.3` に更新 |
 | 2026-05-13 | Chromeウェブストア登録準備：拡張機能アイコン（16/48/128 PNG、雲＋表モチーフ）を追加、プライバシーポリシー（`docs/privacy-policy.md`）を策定、manifest.json に `icons` と `action.default_icon` を設定（[#112](https://github.com/tzhaya/jc-import-file-maker/issues/112)） |
 | 2026-03-29 | shared.js未配置時のフォールバック：警告表示しAPIキーなしで動作継続（[#111](https://github.com/tzhaya/jc-import-file-maker/issues/111)） |
 | 2026-03-29 | CONFIG共通化：APIキー設定（CONFIG）・loadConfig()・extensionFetch()をshared.jsに外部化し両HTML・Chrome拡張で共有、TSVテンプレートをtsv_headers_template.jsに外部化（[#111](https://github.com/tzhaya/jc-import-file-maker/issues/111)） |

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "JAIRO Cloud（WEKO3）に登録するメタデータの作成とインポートを支援するChrome拡張機能です。DOIを入力するだけで、Crossref / JaLC / OpenAlex から書誌メタデータを自動で取得します。",
   "icons": {
     "16": "icons/icon16.png",

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-05-13（Chromeウェブストア登録準備 / 拡張機能アイコン追加 + プライバシーポリシー策定 #112）
+最終更新: 2026-05-14（Chrome拡張 ver. 1.9.3 / ストア公開名と一致するようツール名統一・manifest version更新）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -16,6 +16,7 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.9.3 | 2026-05-14 | ストア公開名と一致するようツール名・タイトルを「JAIRO Cloud インポート支援ツール」に統一（panel.html / options.html / make_jc_importer.html）、ストア再配布用に manifest version を更新 |
 | 1.9.2 | 2026-05-13 | Chromeウェブストア登録準備：拡張機能アイコン（16/48/128 PNG）追加、プライバシーポリシー策定、manifest.jsonにicons/action.default_iconを設定（#112） |
 | 1.9.1 | 2026-03-29 | shared.js未配置時のフォールバック：警告表示+APIキーなしで動作継続（#111） |
 | 1.9.0 | 2026-03-29 | CONFIG共通化：APIキー設定・ユーティリティをshared.jsに外部化、TSVテンプレートをtsv_headers_template.jsに外部化（#111） |
@@ -44,6 +45,31 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 | 1.2.0 | 2026-03-13 | TSVエクスポート機能追加、残存issues優先順位整理 |
 | 1.1.0 | 2026-03-11 | OpenSearch検索タブ統合、JaLCデータ取込修正、書誌情報UI修正、入力モード自動判定 |
 | 1.0.0 | 2026-03-10 | 初期リリース（Manifest V3、Service Worker、OPFモーダル） |
+
+---
+
+## 2026-05-14: Chrome拡張 ver. 1.9.3 — ストア公開名と一致するようツール名統一 + manifest version 更新
+
+### 概要
+Chromeウェブストア公開後の保守として、ストア公開名（「JAIRO Cloud インポート支援ツール」）と拡張機能内 UI のタイトルを揃え、その更新版をストアに再配布できるよう `manifest.json` の `version` を `1.9.2` → `1.9.3` に更新。
+
+### 背景
+- ストア公開名: 「JAIRO Cloud インポート支援ツール」
+- 拡張機能内タイトル: 旧称が一部残存していたため、表記の不一致をなくすため統一（commit `688be70` で `panel.html` / `options.html` / `make_jc_importer.html` を更新）
+- 上記時点では manifest version が据え置きだったため、本変更で 1.9.3 にバンプし、ウェブストア再アップロード可能な状態にした
+
+### 変更ファイル
+- `chrome-extension/manifest.json` — `version` を `1.9.2` → `1.9.3`
+- `README.md` — 最新の更新テーブル・変更履歴テーブルに 2026-05-14 を追記
+- `docs/worklog.md` — バージョン履歴テーブルに 1.9.3 を追記、本セクションを追加
+
+### 配布パッケージ
+- `C:\tmp\jc-import-file-maker-v1.9.3.zip`（16 ファイル、約 106 KB）
+- 同梱: manifest.json, shared.js, tsv_headers_template.js, make_jc_importer.js, funder_lookup.js, panel.html, funder_panel.html, opensearch_panel.html, opensearch_panel.js, options.html, options.js, background.js, icons/{icon.svg, icon16.png, icon48.png, icon128.png}
+- 除外: `icons/generate_icons.py`（開発用スクリプト）
+
+### 機能的変更
+- なし（ストア再配布のための version bump のみ。挙動は 1.9.2 と同等）
 
 ---
 


### PR DESCRIPTION
## Summary
- Chromeウェブストア公開名「JAIRO Cloud インポート支援ツール」と拡張機能内タイトルを揃える変更（commit 688be70）に伴い、ストア再配布できるよう `manifest.json` の `version` を `1.9.2` → `1.9.3` に更新
- 挙動・機能変更はなし。ストア再アップロードのためのバージョン番号バンプのみ
- README.md・docs/worklog.md にも履歴を反映

## 変更ファイル
- `chrome-extension/manifest.json` — `version` 1.9.2 → 1.9.3
- `README.md` — 「最新の更新」テーブル・変更履歴テーブルに 2026-05-14 を追記
- `docs/worklog.md` — バージョン履歴テーブルに 1.9.3 を追記、詳細セクション追加

## 配布パッケージ
- `C:\tmp\jc-import-file-maker-v1.9.3.zip`（16 ファイル、約 106 KB）
- マージ後、Chromeウェブストア デベロッパーダッシュボードからアップロード予定

## Test plan
- [x] manifest.json の `version` が `1.9.3` であることを確認
- [x] zip パッケージ（C:\tmp\jc-import-file-maker-v1.9.3.zip）に `generate_icons.py` が含まれていないことを確認
- [x] zip パッケージを `chrome://extensions` の「パッケージ化されていない拡張機能を読み込む」（展開して読込）で読み込み、バージョン表示が 1.9.3 になることを確認
- [x] panel.html / options.html のタイトルが「JAIRO Cloud インポート支援ツール」になっていることを確認

機能ロジックの変更はないため、E2E テストはスキップ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)