### PR TITLE
chore: Chrome拡張 ver. 1.9.4 — 表示情報整理（5月実作業反映・LOCAL_VERSION同期）

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張機能版 | 2026-05-14 | ver. 1.9.3 | Chromeウェブストア公開名と一致するようツール名・タイトルを「JAIRO Cloud インポート支援ツール」に統一、ストア再配布用にmanifest版数を更新 |
-| インポート用TSV生成ツール | 2026-03-29 | — | shared.js未配置時のフォールバック：警告表示+APIキーなしで動作継続（[#111](https://github.com/tzhaya/jc-import-file-maker/issues/111)） |
+| Chrome拡張機能版 | 2026-05-15 | ver. 1.9.4 | 最終更新日・更新概要テーブルの表示情報を整理し、5月の実作業（ストア登録準備・名前統一）を反映 |
+| インポート用TSV生成ツール | 2026-05-15 | — | 最終更新日・更新概要テーブルの表示情報を整理し、5月の実作業を反映、LOCAL_VERSION 同期 |
 | 助成情報検索ツール | 2026-03-29 | — | shared.js未配置時のフォールバック：警告表示+APIキーなしで動作継続（[#111](https://github.com/tzhaya/jc-import-file-maker/issues/111)） |
 
 ## 導入方法
@@ -276,6 +276,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-05-15 | Chrome拡張機能 ver. 1.9.4：`panel.html` / `make_jc_importer.html` の最終更新日と更新概要テーブルを整理し、5月の実作業（ストア登録準備・名前統一）を直近5件として反映。LOCAL_VERSION（`make_jc_importer.html` / `chrome-extension/make_jc_importer.js`）を `2026-05-15` に同期、manifest version を `1.9.3` → `1.9.4` に更新 |
 | 2026-05-14 | Chrome拡張機能 ver. 1.9.3：Chromeウェブストア公開名と一致するようツール名・タイトルを「JAIRO Cloud インポート支援ツール」に統一（`panel.html` / `options.html` / `make_jc_importer.html`）、ストア再配布用に manifest version を `1.9.2` → `1.9.3` に更新 |
 | 2026-05-13 | Chromeウェブストア登録準備：拡張機能アイコン（16/48/128 PNG、雲＋表モチーフ）を追加、プライバシーポリシー（`docs/privacy-policy.md`）を策定、manifest.json に `icons` と `action.default_icon` を設定（[#112](https://github.com/tzhaya/jc-import-file-maker/issues/112)） |
 | 2026-03-29 | shared.js未配置時のフォールバック：警告表示しAPIキーなしで動作継続（[#111](https://github.com/tzhaya/jc-import-file-maker/issues/111)） |

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -5969,7 +5969,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-03-29';
+  const LOCAL_VERSION = '2026-05-15';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "JAIRO Cloud（WEKO3）に登録するメタデータの作成とインポートを支援するChrome拡張機能です。DOIを入力するだけで、Crossref / JaLC / OpenAlex から書誌メタデータを自動で取得します。",
   "icons": {
     "16": "icons/icon16.png",

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -500,7 +500,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-03-29 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-05-15 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -513,24 +513,24 @@
     </thead>
     <tbody>
       <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-15</td>
+        <td style="padding:2px 0;">Chrome拡張 ver. 1.9.4：最終更新日・更新概要テーブルの表示情報を整理し、5月の実作業を反映</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-14</td>
+        <td style="padding:2px 0;">Chrome拡張 ver. 1.9.3：ストア公開名と一致するようツール名を「JAIRO Cloud インポート支援ツール」に統一（#138, #139）</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-13</td>
+        <td style="padding:2px 0;">Chrome拡張 ver. 1.9.2：Chromeウェブストア登録準備 - 拡張機能アイコン追加 + プライバシーポリシー策定（#112）</td>
+      </tr>
+      <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-29</td>
         <td style="padding:2px 0;">CONFIG共通化：APIキー設定とChrome拡張ユーティリティをshared.jsに外部化、TSVテンプレートをtsv_headers_template.jsに外部化（#111）</td>
       </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-23</td>
         <td style="padding:2px 0;">エンバーゴアクセス権修正：OA Status=closed時のアクセス権をOPFエンバーゴ情報に基づき自動設定、OPF取得タイミング修正（#51）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-22</td>
-        <td style="padding:2px 0;">OA情報統合：OAステータス全6値対応、出版タイプ/relationType/アクセス権の自動設定、リポジトリ情報取得、OPFモーダル連動、エンバーゴヒント表示（#51）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-22</td>
-        <td style="padding:2px 0;">複数DOI一括TSV出力：DOIを連続取得して蓄積し、ヘッダー5行+データN行の一括TSVを出力。リポジトリURL入力でスキーマURL置換対応（#100）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-22</td>
-        <td style="padding:2px 0;">カスタムテンプレート完全パース対応：5行ヘッダー貼り付けでTSVテンプレートを丸ごと上書き、ItemType行の自動設定（#99, #101）</td>
       </tr>
     </tbody>
   </table>

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-05-14（Chrome拡張 ver. 1.9.3 / ストア公開名と一致するようツール名統一・manifest version更新）
+最終更新: 2026-05-15（Chrome拡張 ver. 1.9.4 / 表示情報整理：5月の実作業を更新概要テーブルに反映、LOCAL_VERSION 同期）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -16,6 +16,7 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.9.4 | 2026-05-15 | 表示情報整理：`panel.html` / `make_jc_importer.html` の最終更新日と更新概要テーブル（直近5件）を5月の実作業を反映する形に更新、LOCAL_VERSION（`make_jc_importer.html` / `chrome-extension/make_jc_importer.js`）を `2026-05-15` に同期 |
 | 1.9.3 | 2026-05-14 | ストア公開名と一致するようツール名・タイトルを「JAIRO Cloud インポート支援ツール」に統一（panel.html / options.html / make_jc_importer.html）、ストア再配布用に manifest version を更新 |
 | 1.9.2 | 2026-05-13 | Chromeウェブストア登録準備：拡張機能アイコン（16/48/128 PNG）追加、プライバシーポリシー策定、manifest.jsonにicons/action.default_iconを設定（#112） |
 | 1.9.1 | 2026-03-29 | shared.js未配置時のフォールバック：警告表示+APIキーなしで動作継続（#111） |
@@ -45,6 +46,32 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 | 1.2.0 | 2026-03-13 | TSVエクスポート機能追加、残存issues優先順位整理 |
 | 1.1.0 | 2026-03-11 | OpenSearch検索タブ統合、JaLCデータ取込修正、書誌情報UI修正、入力モード自動判定 |
 | 1.0.0 | 2026-03-10 | 初期リリース（Manifest V3、Service Worker、OPFモーダル） |
+
+---
+
+## 2026-05-15: Chrome拡張 ver. 1.9.4 — 表示情報整理（最終更新日・更新概要テーブルの5月反映）
+
+### 概要
+`chrome-extension/panel.html` と `make_jc_importer.html` の「最終更新」日付および更新概要テーブルが 3月時点のまま（直近の 5月の実作業が未反映）となっていたため、本日（2026-05-15 JST）に整理。テーブルは「直近5件」ルールに従い、古い 2026-03-22 の3件（OA情報統合 / 複数DOI一括TSV / カスタムテンプレート完全パース）を 2026-05-15 / 05-14 / 05-13 の3件に差し替え。あわせて GitHub 更新チェックが参照する `LOCAL_VERSION` を `2026-05-15` に揃え、manifest version を `1.9.3` → `1.9.4` (patch) に更新。
+
+### 背景
+- 1.9.2（ストア登録準備、#112）と 1.9.3（ツール名統一、#138/#139）の作業は実施済みだが、各 HTML 内の「最終更新」日付と更新概要テーブルには反映されていなかった
+- 機能変更なし。表示情報整理のみのため patch バンプ（CLAUDE.md のバージョニング規約「軽微な改善」に該当）
+
+### 変更ファイル
+- `chrome-extension/panel.html` — 最終更新日 `2026-03-29` → `2026-05-15`、更新概要テーブルを直近5件（2026-05-15 / 05-14 / 05-13 / 03-29 / 03-23）に差し替え
+- `make_jc_importer.html` — 同上の差し替え、`LOCAL_VERSION` を `2026-03-29` → `2026-05-15`
+- `chrome-extension/make_jc_importer.js` — `LOCAL_VERSION` を `2026-03-29` → `2026-05-15`（make_jc_importer.html と同期）
+- `chrome-extension/manifest.json` — `version` を `1.9.3` → `1.9.4`
+- `make_jc_importer_test.html`（git管理外）— 上記 HTML 変更を反映（CONFIG セクションのAPIキーは据え置き）
+- `README.md` — 「最新の更新」テーブルおよび変更履歴テーブルに 2026-05-15 を追記
+- `docs/worklog.md` — バージョン履歴テーブルに 1.9.4 を追記、本セクションを追加
+
+### 機能的変更
+- なし（表示情報の整理および GitHub 更新チェック用 LOCAL_VERSION の同期のみ）
+
+### 配布パッケージ（予定）
+- `C:\tmp\jc-import-file-maker-v1.9.4.zip`（ストア再配布が必要な場合）
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -490,7 +490,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-03-29 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-05-15 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -503,24 +503,24 @@
     </thead>
     <tbody>
       <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-15</td>
+        <td style="padding:2px 0;">最終更新日・更新概要テーブルの表示情報を整理し、5月の実作業を反映（Chrome拡張 ver. 1.9.4 と同期）</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-14</td>
+        <td style="padding:2px 0;">Chrome拡張 ver. 1.9.3：ストア公開名と一致するようツール名を「JAIRO Cloud インポート支援ツール」に統一（#138, #139）</td>
+      </tr>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-13</td>
+        <td style="padding:2px 0;">Chrome拡張 ver. 1.9.2：Chromeウェブストア登録準備 - 拡張機能アイコン追加 + プライバシーポリシー策定（#112）</td>
+      </tr>
+      <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-29</td>
         <td style="padding:2px 0;">CONFIG共通化：APIキー設定とChrome拡張ユーティリティをshared.jsに外部化、TSVテンプレートをtsv_headers_template.jsに外部化（#111）</td>
       </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-23</td>
         <td style="padding:2px 0;">エンバーゴアクセス権修正：OA Status=closed時のアクセス権をOPFエンバーゴ情報に基づき自動設定、OPF取得タイミング修正（#51）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-22</td>
-        <td style="padding:2px 0;">OA情報統合：OAステータス全6値対応、出版タイプ/relationType/アクセス権の自動設定、リポジトリ情報取得、OPFモーダル連動、エンバーゴヒント表示（#51）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-22</td>
-        <td style="padding:2px 0;">複数DOI一括TSV出力：DOIを連続取得して蓄積し、ヘッダー5行+データN行の一括TSVを出力。リポジトリURL入力でスキーマURL置換対応（#100）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-22</td>
-        <td style="padding:2px 0;">カスタムテンプレート完全パース対応：5行ヘッダー貼り付けでTSVテンプレートを丸ごと上書き、ItemType行の自動設定（#99, #101）</td>
       </tr>
     </tbody>
   </table>
@@ -6622,7 +6622,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-03-29';
+  const LOCAL_VERSION = '2026-05-15';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;


### PR DESCRIPTION
## Summary

- `chrome-extension/panel.html` / `make_jc_importer.html` の「最終更新」日付と更新概要テーブルが 3月のままだったため、本日（2026-05-15 JST）に整理。直近5件ルールに従い、古い 2026-03-22 の3件を 5月の実作業（[#112](https://github.com/tzhaya/jc-import-file-maker/issues/112) ストア登録準備 / [#138](https://github.com/tzhaya/jc-import-file-maker/pull/138)・[#139](https://github.com/tzhaya/jc-import-file-maker/pull/139) ツール名統一）に差し替え
- GitHub 更新チェックが参照する `LOCAL_VERSION` を `make_jc_importer.html` / `chrome-extension/make_jc_importer.js` ともに `2026-05-15` に同期
- `chrome-extension/manifest.json` の `version` を `1.9.3` → `1.9.4`（patch）

## 変更ファイル

- `chrome-extension/panel.html` — 最終更新日 + 更新概要テーブル（直近5件）
- `make_jc_importer.html` — 同上 + `LOCAL_VERSION` 同期
- `chrome-extension/make_jc_importer.js` — `LOCAL_VERSION` 同期
- `chrome-extension/manifest.json` — version 1.9.3 → 1.9.4
- `README.md` — 「最新の更新」テーブル + 変更履歴に 2026-05-15 追記
- `docs/worklog.md` — バージョン履歴 1.9.4 + 詳細セクション追記

機能変更はありません（表示情報の整理および GitHub 更新チェック用バージョン文字列の同期のみ）。

## Test plan

- [x] E2E (main): `10.1016/j.advnut.2025.100480` で `make_jc_importer_test.html` を検証 — ALL PASSED（タイトル / 著者2人 / DOIリンク / 資源タイプ `journal article` / 33セクション）
- [x] E2E (funder): main で検出された `JP19KK0341` で `funder_lookup_test.html` を検証 — ALL PASSED（KAKEN ヒット、助成機関「日本学術振興会」取得確認）

## マージ方法

ローカル `master` が `origin/master` より2コミット（[#140](https://github.com/tzhaya/jc-import-file-maker/pull/140) GitHub Actions ワークフロー）遅れたタイミングで分岐したため、PR 上の **Rebase and merge** で取り込みをお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)