### PR TITLE
fix: IndexID・公開日のTSV出力バグ修正、管理フィールドのヒント誤り修正 (#142, #143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張機能版 | 2026-05-15 | ver. 1.9.4 | 最終更新日・更新概要テーブルの表示情報を整理し、5月の実作業（ストア登録準備・名前統一）を反映 |
-| インポート用TSV生成ツール | 2026-05-15 | — | 最終更新日・更新概要テーブルの表示情報を整理し、5月の実作業を反映、LOCAL_VERSION 同期 |
+| Chrome拡張機能版 | 2026-06-06 | ver. 1.9.5 | IndexID・公開日がTSVに出力されないバグ修正（[#142](https://github.com/tzhaya/jc-import-file-maker/issues/142)）、管理フィールドのIndexID/POS_INDEX候補値ヒント誤りを修正（[#143](https://github.com/tzhaya/jc-import-file-maker/issues/143)） |
+| インポート用TSV生成ツール | 2026-06-06 | — | IndexID・公開日がTSVに出力されないバグ修正（[#142](https://github.com/tzhaya/jc-import-file-maker/issues/142)）、管理フィールドのIndexID/POS_INDEX候補値ヒント誤りを修正（[#143](https://github.com/tzhaya/jc-import-file-maker/issues/143)） |
 | 助成情報検索ツール | 2026-03-29 | — | shared.js未配置時のフォールバック：警告表示+APIキーなしで動作継続（[#111](https://github.com/tzhaya/jc-import-file-maker/issues/111)） |
 
 ## 導入方法
@@ -276,6 +276,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-06-06 | IndexID・公開日がTSVに出力されないバグを修正：`groupTsvColumns()` 内 `.metadata.path[0]` / `.metadata.pubdate` が `__other__` に分類されTSVスキップされていた問題を `__system__` に変更して解消（[#142](https://github.com/tzhaya/jc-import-file-maker/issues/142)）。管理フィールドのIndexID/POS_INDEX候補値ヒント誤り（入れ違い）を修正（[#143](https://github.com/tzhaya/jc-import-file-maker/issues/143)）。manifest version `1.9.4` → `1.9.5` |
 | 2026-05-15 | Chrome拡張機能 ver. 1.9.4：`panel.html` / `make_jc_importer.html` の最終更新日と更新概要テーブルを整理し、5月の実作業（ストア登録準備・名前統一）を直近5件として反映。LOCAL_VERSION（`make_jc_importer.html` / `chrome-extension/make_jc_importer.js`）を `2026-05-15` に同期、manifest version を `1.9.3` → `1.9.4` に更新 |
 | 2026-05-14 | Chrome拡張機能の配布用zipパッケージ作成をGitHub Actionsで自動化：`v*` タグpush時に `chrome-extension/` を `git archive` でzip化し、tag↔manifest version整合チェックの上で GitHub Releases へ自動添付（`.github/workflows/release.yml`） |
 | 2026-05-14 | Chrome拡張機能 ver. 1.9.3：Chromeウェブストア公開名と一致するようツール名・タイトルを「JAIRO Cloud インポート支援ツール」に統一（`panel.html` / `options.html` / `make_jc_importer.html`）、ストア再配布用に manifest version を `1.9.2` → `1.9.3` に更新 |

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -685,7 +685,7 @@ function renderSystemFields(systemData) {
     { label: '.id',                  hint: '新規登録時は空欄', key: 'sys_id',      type: 'text',   default: '' },
     { label: '.uri',                 hint: '新規登録時は空欄', key: 'sys_uri',     type: 'text',   default: '' },
     { label: '.IndexID[0]',          hint: '1697430475875',     key: 'sys_path',  type: 'text',   default: '' },
-    { label: '.POS_INDEX[0]',        hint: '【テスト】学術雑誌論文', key: 'sys_pos', type: 'text',   default: '' },
+    { label: '.POS_INDEX[0]',        hint: '学術雑誌論文',          key: 'sys_pos', type: 'text',   default: '' },
     { label: '.PUBLISH_STATUS',      hint: 'private / public', key: 'sys_status',  type: 'select', options: ['private','public'], default: 'private' },
     { label: '.FEEDBACK_MAIL[0]',    hint: '',                  key: 'sys_mail',   type: 'text',   default: '' },
     { label: '.RESEAECHMAP_LINKAGE', hint: '',                  key: 'sys_researchmap', type: 'text', default: '' },

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -684,8 +684,8 @@ function renderSystemFields(systemData) {
   const sysRows = [
     { label: '.id',                  hint: '新規登録時は空欄', key: 'sys_id',      type: 'text',   default: '' },
     { label: '.uri',                 hint: '新規登録時は空欄', key: 'sys_uri',     type: 'text',   default: '' },
-    { label: '.IndexID[0]',          hint: '.metadata.path[0]', key: 'sys_path',  type: 'text',   default: '' },
-    { label: '.POS_INDEX[0]',        hint: '1718256617194',    key: 'sys_pos',     type: 'text',   default: '' },
+    { label: '.IndexID[0]',          hint: '1697430475875',     key: 'sys_path',  type: 'text',   default: '' },
+    { label: '.POS_INDEX[0]',        hint: '【テスト】学術雑誌論文', key: 'sys_pos', type: 'text',   default: '' },
     { label: '.PUBLISH_STATUS',      hint: 'private / public', key: 'sys_status',  type: 'select', options: ['private','public'], default: 'private' },
     { label: '.FEEDBACK_MAIL[0]',    hint: '',                  key: 'sys_mail',   type: 'text',   default: '' },
     { label: '.RESEAECHMAP_LINKAGE', hint: '',                  key: 'sys_researchmap', type: 'text', default: '' },
@@ -5364,7 +5364,7 @@ function groupTsvColumns(prefix, template) {
       fieldKey = '.metadata.item_30002_file35';
     } else if (lookupKey.startsWith('.metadata.')) {
       const m = lookupKey.match(/^(\.metadata\.item_[^.\[]+)/);
-      fieldKey = m ? m[1] : '__other__';
+      fieldKey = m ? m[1] : '__system__';
     } else {
       fieldKey = '__system__';
     }
@@ -5969,7 +5969,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-05-15';
+  const LOCAL_VERSION = '2026-06-06';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "JAIRO Cloud（WEKO3）に登録するメタデータの作成とインポートを支援するChrome拡張機能です。DOIを入力するだけで、Crossref / JaLC / OpenAlex から書誌メタデータを自動で取得します。",
   "icons": {
     "16": "icons/icon16.png",

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -500,7 +500,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-05-15 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-06-06 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -512,6 +512,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-06</td>
+        <td style="padding:2px 0;">Chrome拡張 ver. 1.9.5：IndexID・公開日がTSVに出力されないバグ修正（#142）、管理フィールドのIndexID/POS_INDEX候補値ヒント誤りを修正（#143）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-15</td>
         <td style="padding:2px 0;">Chrome拡張 ver. 1.9.4：最終更新日・更新概要テーブルの表示情報を整理し、5月の実作業を反映</td>
@@ -527,10 +531,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-29</td>
         <td style="padding:2px 0;">CONFIG共通化：APIキー設定とChrome拡張ユーティリティをshared.jsに外部化、TSVテンプレートをtsv_headers_template.jsに外部化（#111）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-23</td>
-        <td style="padding:2px 0;">エンバーゴアクセス権修正：OA Status=closed時のアクセス権をOPFエンバーゴ情報に基づき自動設定、OPF取得タイミング修正（#51）</td>
       </tr>
     </tbody>
   </table>

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-05-15（Chrome拡張 ver. 1.9.4 / 表示情報整理：5月の実作業を更新概要テーブルに反映、LOCAL_VERSION 同期）
+最終更新: 2026-06-06（Chrome拡張 ver. 1.9.5 / #142: IndexID・公開日TSV出力バグ修正、#143: IndexID/POS_INDEX候補値ヒント誤り修正）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -16,6 +16,7 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.9.5 | 2026-06-06 | #142: `groupTsvColumns()` 内 `.metadata.path[0]`/`.metadata.pubdate` が `__other__` に分類されTSVスキップされていたバグを修正（`__system__` に変更）、#143: 管理フィールドのIndexID/POS_INDEX候補値ヒントの入れ違いを修正 |
 | 1.9.4 | 2026-05-15 | 表示情報整理：`panel.html` / `make_jc_importer.html` の最終更新日と更新概要テーブル（直近5件）を5月の実作業を反映する形に更新、LOCAL_VERSION（`make_jc_importer.html` / `chrome-extension/make_jc_importer.js`）を `2026-05-15` に同期 |
 | 1.9.3 | 2026-05-14 | ストア公開名と一致するようツール名・タイトルを「JAIRO Cloud インポート支援ツール」に統一（panel.html / options.html / make_jc_importer.html）、ストア再配布用に manifest version を更新 |
 | 1.9.2 | 2026-05-13 | Chromeウェブストア登録準備：拡張機能アイコン（16/48/128 PNG）追加、プライバシーポリシー策定、manifest.jsonにicons/action.default_iconを設定（#112） |
@@ -46,6 +47,25 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 | 1.2.0 | 2026-03-13 | TSVエクスポート機能追加、残存issues優先順位整理 |
 | 1.1.0 | 2026-03-11 | OpenSearch検索タブ統合、JaLCデータ取込修正、書誌情報UI修正、入力モード自動判定 |
 | 1.0.0 | 2026-03-10 | 初期リリース（Manifest V3、Service Worker、OPFモーダル） |
+
+---
+
+## 2026-06-06: Chrome拡張 ver. 1.9.5 — IndexID/公開日TSV出力バグ修正、管理フィールドヒント誤り修正 (#142, #143)
+
+### 概要
+2つのバグを修正。
+
+**#142**: `groupTsvColumns()` 内で `.metadata.path[0]`（IndexID）と `.metadata.pubdate`（公開日）が `__other__` に分類されてしまい、対応する `metadata['__other__']` が `undefined` となりTSVがスキップされていた。`.metadata.item_` にマッチしない `.metadata.*` 系フィールドも `__system__` として扱うよう1行修正。
+
+**#143**: 管理フィールドの候補値ヒントが入れ違い。`.IndexID[0]` に表示される候補値が `.metadata.path[0]`（プロパティパス名）、`.POS_INDEX[0]` に数値IDが表示されていたが、正しくは IndexID には数値ID（例: `1697430475875`）、POS_INDEX にはインデックスラベル（例: `【テスト】学術雑誌論文`）。
+
+### 変更ファイル
+- `make_jc_importer.html` — `groupTsvColumns()`: `'__other__'` → `'__system__'`、`sysRows` IndexID/POS_INDEX hint 修正、最終更新日・更新概要テーブル更新、`LOCAL_VERSION` `2026-05-15` → `2026-06-06`
+- `chrome-extension/make_jc_importer.js` — 同上3件を同期
+- `chrome-extension/panel.html` — 最終更新日・更新概要テーブル更新
+- `chrome-extension/manifest.json` — `version` `1.9.4` → `1.9.5`
+- `README.md` — 「最新の更新」テーブルおよび変更履歴テーブルに 2026-06-06 を追記
+- `docs/worklog.md` — バージョン履歴テーブルに 1.9.5 を追記、本セクションを追加
 
 ---
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -490,7 +490,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-05-15 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-06-06 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -502,6 +502,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-06</td>
+        <td style="padding:2px 0;">IndexID・公開日がTSVに出力されないバグ修正（#142）、管理フィールドのIndexID/POS_INDEX候補値ヒント誤りを修正（#143）（Chrome拡張 ver. 1.9.5 と同期）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-15</td>
         <td style="padding:2px 0;">最終更新日・更新概要テーブルの表示情報を整理し、5月の実作業を反映（Chrome拡張 ver. 1.9.4 と同期）</td>
@@ -517,10 +521,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-29</td>
         <td style="padding:2px 0;">CONFIG共通化：APIキー設定とChrome拡張ユーティリティをshared.jsに外部化、TSVテンプレートをtsv_headers_template.jsに外部化（#111）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-23</td>
-        <td style="padding:2px 0;">エンバーゴアクセス権修正：OA Status=closed時のアクセス権をOPFエンバーゴ情報に基づき自動設定、OPF取得タイミング修正（#51）</td>
       </tr>
     </tbody>
   </table>
@@ -1336,8 +1336,8 @@ function renderSystemFields(systemData) {
   const sysRows = [
     { label: '.id',                  hint: '新規登録時は空欄', key: 'sys_id',      type: 'text',   default: '' },
     { label: '.uri',                 hint: '新規登録時は空欄', key: 'sys_uri',     type: 'text',   default: '' },
-    { label: '.IndexID[0]',          hint: '.metadata.path[0]', key: 'sys_path',  type: 'text',   default: '' },
-    { label: '.POS_INDEX[0]',        hint: '1718256617194',    key: 'sys_pos',     type: 'text',   default: '' },
+    { label: '.IndexID[0]',          hint: '1697430475875',     key: 'sys_path',  type: 'text',   default: '' },
+    { label: '.POS_INDEX[0]',        hint: '【テスト】学術雑誌論文', key: 'sys_pos', type: 'text',   default: '' },
     { label: '.PUBLISH_STATUS',      hint: 'private / public', key: 'sys_status',  type: 'select', options: ['private','public'], default: 'private' },
     { label: '.FEEDBACK_MAIL[0]',    hint: '',                  key: 'sys_mail',   type: 'text',   default: '' },
     { label: '.RESEAECHMAP_LINKAGE', hint: '',                  key: 'sys_researchmap', type: 'text', default: '' },
@@ -6017,7 +6017,7 @@ function groupTsvColumns(prefix, template) {
       fieldKey = '.metadata.item_30002_file35';
     } else if (lookupKey.startsWith('.metadata.')) {
       const m = lookupKey.match(/^(\.metadata\.item_[^.\[]+)/);
-      fieldKey = m ? m[1] : '__other__';
+      fieldKey = m ? m[1] : '__system__';
     } else {
       fieldKey = '__system__';
     }
@@ -6622,7 +6622,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-05-15';
+  const LOCAL_VERSION = '2026-06-06';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -1337,7 +1337,7 @@ function renderSystemFields(systemData) {
     { label: '.id',                  hint: '新規登録時は空欄', key: 'sys_id',      type: 'text',   default: '' },
     { label: '.uri',                 hint: '新規登録時は空欄', key: 'sys_uri',     type: 'text',   default: '' },
     { label: '.IndexID[0]',          hint: '1697430475875',     key: 'sys_path',  type: 'text',   default: '' },
-    { label: '.POS_INDEX[0]',        hint: '【テスト】学術雑誌論文', key: 'sys_pos', type: 'text',   default: '' },
+    { label: '.POS_INDEX[0]',        hint: '学術雑誌論文',          key: 'sys_pos', type: 'text',   default: '' },
     { label: '.PUBLISH_STATUS',      hint: 'private / public', key: 'sys_status',  type: 'select', options: ['private','public'], default: 'private' },
     { label: '.FEEDBACK_MAIL[0]',    hint: '',                  key: 'sys_mail',   type: 'text',   default: '' },
     { label: '.RESEAECHMAP_LINKAGE', hint: '',                  key: 'sys_researchmap', type: 'text', default: '' },


### PR DESCRIPTION
## Summary

- **#142**: `groupTsvColumns()` 内で `.metadata.path[0]`（IndexID列）と `.metadata.pubdate`（公開日列）が `__other__` グループに分類され、TSVに出力されなかったバグを修正（`__system__` に変更）
- **#143**: 管理フィールドの候補値ヒントの誤りを修正
  - `.IndexID[0]`: `.metadata.path[0]`（プロパティパス名）→ `1697430475875`（数値IDの例）
  - `.POS_INDEX[0]`: `1718256617194`（数値ID）→ `学術雑誌論文`（インデックスラベルの例）
- Chrome拡張 manifest version: `1.9.4` → `1.9.5`、`LOCAL_VERSION`: `2026-05-15` → `2026-06-06`

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `make_jc_importer.html` | `groupTsvColumns()` 修正、`sysRows` ヒント修正、最終更新テーブル更新、`LOCAL_VERSION` 更新 |
| `chrome-extension/make_jc_importer.js` | 同上を同期 |
| `chrome-extension/panel.html` | 最終更新テーブル更新 |
| `chrome-extension/manifest.json` | `1.9.4` → `1.9.5` |
| `README.md` | 「最新の更新」・変更履歴テーブル更新 |
| `docs/worklog.md` | バージョン履歴・実装セクション追加 |

## Test plan

- [x] E2E テスト（main）: DOI `10.1016/j.advnut.2025.100480` — ALL PASSED
- [x] E2E テスト（funder）: 課題番号 `JP19KK0341` — ALL PASSED

🤖 Generated with [Claude Code](https://claude.ai/claude-code)