### PR TITLE
docs: README・使い方ガイドを現在の実装に同期

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 概要
 
-DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO Cloud](https://jpcoar.org/support/jairo-cloud/)へのインポート用TSVファイルを生成するツールです。
+DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO Cloud](https://jpcoar.org/support/jairo-cloud/)へのインポート用TSVファイルを生成するツールです。Chrome拡張機能版では、閲覧中の電子ジャーナルページからDOIを自動取得することもできます。
 
 特に、以下の課題の解決を目指しています。
 
@@ -33,6 +33,7 @@ DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO
     - JAIRO Cloud インポート用TSV生成ツール
     - 助成情報検索ツール
     - 機関リポジトリのメタデータ検索（OpenSearch）
+  - 閲覧中の電子ジャーナルページからのDOI自動取得（「ページからDOI取得」ボタン）
   - JaLC DOIからのメタデータ取り込み
   - KAKEN APIによる科研費課題番号の検索と取り込み
   - Open Policy Finderから取得したOAポリシーの表示とエンバーゴの設定
@@ -50,6 +51,7 @@ DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO
 | Open Policy Finder API によるOAポリシー表示 | ✅ | ❌ | CORS制約のためChrome拡張機能版のみ |
 | Open Policy Finder API の情報によるエンバーゴ有無と期間の設定 | ✅ | ❌ | CORS制約のためChrome拡張機能版のみ |
 | **メタデータ取得** | | | |
+| 閲覧中ページからのDOI自動取得 | ✅ | ❌ | 電子ジャーナルページのmetaタグから取得（ボタン押下時のみ） |
 | Crossref DOI からのメタデータ取得 | ✅ | ✅ | |
 | JaLC DOI からのメタデータ取得 | ✅ | ❌ | CORS制約のためChrome拡張機能のService Worker経由が必要 |
 | DataCite DOI からのメタデータ取得 | ❌ | ❌ | 未対応です |
@@ -63,6 +65,7 @@ DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO
 | **収録物識別子補完** | | | |
 | NCID 自動取得 | ✅ | ✅ | ISSNからCiNii Researchを検索 |
 | **助成情報補完** | | | |
+| DOIからの課題番号自動取得（助成情報検索ツール） | ✅ | ✅ | Crossref/OpenAlex APIから課題番号を抽出 |
 | JGN（科学技術振興機構）課題番号検索 | ✅ | ✅ |  |
 | CiNii Research API による科研費課題名取得 | ✅ | ✅ |  |
 | KAKEN XML API による科研費課題検索 | ✅ | ❌ | CORS制約のためChrome拡張機能版のみ |
@@ -126,14 +129,15 @@ HTMLファイルを直接ブラウザで開いて使用します。
 **このツールはベータ版です。**
 **アイテムタイプ「デフォルトアイテムタイプ（フル）」の形式でのインポート用TSVファイルのみ生成できます。なお、インポートは未検証です。正しく取り込まれないことがあります。**
 
-現在のバージョン（Phase 1）では、APIからのデータ取得・マッピング・編集UIが実装されています。
+APIからのデータ取得・マッピング・編集UI・プレビュー・TSV出力（複数DOIの一括出力を含む）が実装されています。
 
 1. DOIを「DOI」の入力欄に入力します。
+   - （Chrome拡張機能版のみ）電子ジャーナルの論文ページを開いた状態で「ページからDOI取得」ボタンを押すと、ページのmetaタグからDOIを自動入力できます。
 2. 「データ取得」ボタンを押します
 3. Crossrefなどから必要なメタデータを取得して、「メタデータ確認・編集」として表示します。編集も可能です。
 4. 「プレビュー表示」ボタンでプレビューができます。
 5. （Chrome拡張機能版のみ）外国雑誌等でOpen Policy Finderに登録されている雑誌にはDOIの隣に「OAポリシー」のボタンが表示されます。クリックすると、Open Policy Finderから取得したオープンアクセスにできる版や掲載場所の情報を表示します。
-6. TSVファイルとしてダウンロードができます（β版提供中：未検証です）
+6. TSVファイルとしてダウンロードができます（β版提供中：未検証です）。複数のDOIを連続取得して1つのTSVファイルにまとめて出力することもできます。
 
 詳しい使い方と取得したデータの取り扱いは[使い方ガイド](docs/user_guide.md)を参照ください。
 
@@ -143,10 +147,12 @@ HTMLファイルを直接ブラウザで開いて使用します。
 - 科研費課題番号やJGN課題番号から、助成機関識別子・助成機関名・プログラム情報・研究課題名を検索します。
 - Chrome拡張機能版ではサイドパネルのタブから「助成情報検索」に切り替えて利用できます。
 - 通常ブラウザ版では [funder_lookup.html](https://github.com/tzhaya/jc-import-file-maker/raw/refs/heads/master/funder_lookup.html) を右クリック→「名前をつけてリンク(先)を保存」で保存してご利用ください。
+  - 動作には [shared.js](https://github.com/tzhaya/jc-import-file-maker/raw/refs/heads/master/shared.js) も必要です。同じフォルダに保存してください（インポート用TSV生成ツールの導入時に保存済みであれば共用できます）。
 
 #### 利用方法
 
 1. 科研費課題番号やJGN課題番号、論文の謝辞（Acknowledgement）をコピー＆ペーストして「検索」を押します。
+     - 論文のDOIがわかっている場合は、「DOI（任意）」欄にDOIを入力して「課題番号を取得」を押すと、Crossref/OpenAlex APIから課題番号を自動取得して入力欄に追加できます。
 2. JPCOAR 2.0 準拠の助成情報（助成機関識別子・助成機関名・プログラム情報・研究課題名）を検索できます。
      - ヒットしない場合は、以下の参照用リンクを表示します。
        - [体系的番号](https://www.nistep.go.jp/taikei/)（NISTEP）
@@ -200,7 +206,7 @@ const CONFIG = {
 };
 ```
 
-#### OpenAlex API Key（必須）
+#### OpenAlex API Key（推奨）
 
 OpenAlex APIは、APIキーなしでの利用回数に制限があります。継続的に利用する場合は、APIキーの設定を推奨します。
 
@@ -220,8 +226,10 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 ## ディレクトリ構成
 
 ```
-├── make_jc_importer.html      # メインツール（通常ブラウザ版・単一HTMLファイル）
+├── make_jc_importer.html      # メインツール（通常ブラウザ版）
 ├── funder_lookup.html         # 助成情報検索ツール（通常ブラウザ版）
+├── shared.js                  # 共通設定（CONFIG定数・APIキー）と通信処理（両HTML・Chrome拡張で共有）
+├── tsv_headers_template.js    # TSVヘッダーテンプレート定義（メインツールで使用）
 ├── chrome-extension/          # Chrome拡張機能版（このフォルダを読み込んで使用）
 │   ├── manifest.json          #   Manifest V3 定義
 │   ├── background.js          #   Service Worker（CORS プロキシ）
@@ -229,8 +237,13 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 │   ├── make_jc_importer.js    #   メインツール ロジック
 │   ├── funder_panel.html      #   サイドパネル（助成情報検索）
 │   ├── funder_lookup.js       #   助成情報検索 ロジック
+│   ├── opensearch_panel.html  #   サイドパネル（OpenSearch検索）
+│   ├── opensearch_panel.js    #   OpenSearch検索 ロジック
 │   ├── options.html           #   設定ページ（APIキー管理 UI）
-│   └── options.js             #   設定ページ ロジック
+│   ├── options.js             #   設定ページ ロジック
+│   ├── shared.js              #   ルートの shared.js の同期コピー
+│   ├── tsv_headers_template.js#   ルートの tsv_headers_template.js の同期コピー
+│   └── icons/                 #   拡張機能アイコン（16/48/128 PNG + SVG）
 ├── api-flow.md                # APIフロー整理（Crossref/OpenAlex等の取得順・JPCOARマッピング）
 ├── data/                      # 参照・設定データ
 │   ├── ItemType.json          # JAIRO Cloud アイテムタイプ定義
@@ -276,6 +289,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-06-10 | ドキュメント整合性修正：README・使い方ガイドを現在の実装に同期（#73新機能の反映、`shared.js`/`tsv_headers_template.js` 依存の明記、TSV出力ファイル名の記述修正、機能比較表・ディレクトリ構成の更新） |
 | 2026-06-10 | 電子ジャーナルページのmetaタグ（`citation_doi`, `prism.doi`, `DOI`, `dc.identifier`）からDOIを自動取得するボタンをDOIインポートタブに追加。助成情報検索タブにDOI入力欄を新設し、Crossref/OpenAlex APIから課題番号を自動抽出してテキストエリアへ流し込む機能を追加（[#73](https://github.com/tzhaya/jc-import-file-maker/issues/73)）。manifest version `1.9.5` → `1.10.0` |
 | 2026-06-06 | IndexID・公開日がTSVに出力されないバグを修正：`groupTsvColumns()` 内 `.metadata.path[0]` / `.metadata.pubdate` が `__other__` に分類されTSVスキップされていた問題を `__system__` に変更して解消（[#142](https://github.com/tzhaya/jc-import-file-maker/issues/142)）。管理フィールドのIndexID/POS_INDEX候補値ヒント誤り（入れ違い）を修正（[#143](https://github.com/tzhaya/jc-import-file-maker/issues/143)）。manifest version `1.9.4` → `1.9.5` |
 | 2026-05-15 | Chrome拡張機能 ver. 1.9.4：`panel.html` / `make_jc_importer.html` の最終更新日と更新概要テーブルを整理し、5月の実作業（ストア登録準備・名前統一）を直近5件として反映。LOCAL_VERSION（`make_jc_importer.html` / `chrome-extension/make_jc_importer.js`）を `2026-05-15` に同期、manifest version を `1.9.3` → `1.9.4` に更新 |

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -4,7 +4,7 @@
 
 JAIRO Cloud (WEKO3) にメタデータをインポートするためのTSVファイルを生成するツールです。DOIを入力するだけで、Crossref・OpenAlex・JaLC などのAPIからメタデータを自動取得し、JPCOAR スキーマに準拠した形式で編集・確認できます。
 
-単一のHTMLファイル (`make_jc_importer.html`) をブラウザで開くだけで使用でき、インストールは不要です。
+通常ブラウザ版は、3つのファイル（`make_jc_importer.html`・`shared.js`・`tsv_headers_template.js`）を同じフォルダに置いて `make_jc_importer.html` をブラウザで開くだけで使用でき、インストールは不要です。サイドパネルで利用できるChrome拡張機能版もあります（導入方法は [README](../README.md#導入方法) を参照）。
 
 ---
 
@@ -31,6 +31,7 @@ JAIRO Cloud (WEKO3) にメタデータをインポートするためのTSVファ
 1. **DOI入力欄** に対象論文のDOIを入力します
    - 例: `10.1016/j.advnut.2025.100480`
    - `https://doi.org/` 付きのURLでも入力できます
+   - （Chrome拡張機能版のみ）電子ジャーナルの論文ページを開いた状態で **「ページからDOI取得」ボタン** をクリックすると、ページのmetaタグ（`citation_doi` など）からDOIを自動入力できます
 2. **「データ取得」ボタン** をクリック（またはEnterキー）します
 3. データ取得中は「⏳ データを取得中です…」と表示されます
 4. 取得が完了すると、DOIリンクとオープンアクセス状態、（Chrome拡張のみ）Open Policy Finderへのリンクが表示され、下部にメタデータ編集エリアが出現します
@@ -53,7 +54,7 @@ JAIRO Cloud (WEKO3) にメタデータをインポートするためのTSVファ
 #### データ取り込みの詳細
 
 Crossrefから得られる情報を元に、OpenAlex、ROR、CiNii Research、KAKEN XML、JGN（Japan Grant Number）、Open Policy Finder（OPF）からの情報で補完しています。
-詳しくは [api-flow.md](/api-flow.md) を参照してください。
+詳しくは [api-flow.md](../api-flow.md) を参照してください。
 
 1. 共通
    - 「⚠ 要確認」と赤字で表示された場合は、OpenAlexから取り込んだ情報を示します。
@@ -209,7 +210,7 @@ TSV出力時に、TSVヘッダー1行目のスキーマURLを機関リポジト�
 
 #### TSV出力
 
-- **1件のみ**: `import.tsv` のファイル名で出力されます
+- **1件のみ**: DOIをベースにしたファイル名（例: `10.1016_j.advnut.2025.100480.tsv`、DOI中の `/` は `_` に置換）で出力されます
 - **複数件**: `import_YYYYMMDD_HHMMSS.tsv` のタイムスタンプ付きファイル名で出力されます
 - TSVファイルは5行のヘッダー + N行のデータ行（アイテムごとに1行）で構成されます
 
@@ -226,7 +227,7 @@ TSV出力時に、TSVヘッダー1行目のスキーマURLを機関リポジト�
 
 ## APIキーの設定（任意）
 
-ソースコード内の `CONFIG` 定数でAPIキーを設定できます。
+通常ブラウザ版では `shared.js` 内の `CONFIG` 定数を、Chrome拡張機能版では拡張機能のオプションページ（設定ページ）でAPIキーを設定できます。
 
 | キー | 用途 | 未設定時 |
 |------|------|---------|

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-06-10（Chrome拡張 ver. 1.10.0 / #73: 電子ジャーナルページからのDOI自動取り込み）
+最終更新: 2026-06-10（README・使い方ガイドのドキュメント整合性修正）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -48,6 +48,28 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 | 1.2.0 | 2026-03-13 | TSVエクスポート機能追加、残存issues優先順位整理 |
 | 1.1.0 | 2026-03-11 | OpenSearch検索タブ統合、JaLCデータ取込修正、書誌情報UI修正、入力モード自動判定 |
 | 1.0.0 | 2026-03-10 | 初期リリース（Manifest V3、Service Worker、OPFモーダル） |
+
+---
+
+## 2026-06-10: README・使い方ガイドのドキュメント整合性修正
+
+### 概要
+`README.md` と `docs/user_guide.md` を現在の実装（Chrome拡張 ver. 1.10.0 / #73 マージ後）と突き合わせてレビューし、事実と異なる記述・新機能の未反映箇所を修正。コード変更なし（ドキュメントのみ）。
+
+### README.md の修正内容
+- 概要・Chrome拡張版機能リスト・機能比較表に #73 の新機能（閲覧中ページからのDOI自動取得、助成情報検索のDOIからの課題番号自動取得）を反映
+- 助成情報検索ツールの通常ブラウザ版導入手順に `shared.js` の保存が必要な旨を追記（#111 以降の必須依存だが記載漏れ）
+- 助成情報検索ツールの利用方法にDOI入力欄の手順を追加
+- 「使い方」の「現在のバージョン（Phase 1）では…」を Phase 2 完了後の現状（プレビュー・複数DOI一括TSV出力を含む）に更新
+- 「OpenAlex API Key（必須）」見出しを本文（任意・推奨）と整合する「（推奨）」に修正
+- ディレクトリ構成に `shared.js` / `tsv_headers_template.js`（ルート・chrome-extension 双方）、`opensearch_panel.html` / `opensearch_panel.js`、`icons/` を追加
+
+### docs/user_guide.md の修正内容
+- 冒頭の「単一のHTMLファイルを開くだけ」を3ファイル構成（`make_jc_importer.html` + `shared.js` + `tsv_headers_template.js`）に修正し、Chrome拡張版への導線を追加
+- STEP 1 に「ページからDOI取得」ボタン（Chrome拡張版のみ）の説明を追加
+- TSV出力ファイル名の記述を実装に合わせて修正：1件のみの場合は `import.tsv` ではなく `{DOI}.tsv`（`/`→`_` 置換、`exportTsv()` 参照）
+- APIキー設定の記述を「`shared.js` の `CONFIG` 定数（通常版）/ オプションページ（Chrome拡張版）」に修正
+- `api-flow.md` へのリンクをルート相対 `/api-flow.md` から相対パス `../api-flow.md` に修正
 
 ---
 


### PR DESCRIPTION
## 概要

README.md と docs/user_guide.md を現在の実装（Chrome拡張 ver. 1.10.0 / #73 マージ後）と突き合わせてレビューし、事実と異なる記述・新機能の未反映箇所を修正しました。**コード変更はありません（ドキュメントのみ）。**

## 修正内容

### 事実と異なっていた記述の修正
- **user_guide.md 冒頭**: 「単一のHTMLファイルを開くだけ」→ #111 以降は `shared.js` + `tsv_headers_template.js` が必要なため、3ファイル構成の説明に修正。Chrome拡張版への導線も追加
- **user_guide.md TSV出力**: 1件時のファイル名「`import.tsv`」→ 実装（`exportTsv()`）に合わせて `{DOI}.tsv`（`/`→`_` 置換）に修正
- **README OpenAlex API Key 見出し**: 「（必須）」が本文（任意・推奨）と矛盾していたため「（推奨）」に修正
- **README 助成情報検索ツール導入手順**: `funder_lookup.html` は `shared.js` を読み込むため（#111）、`shared.js` の保存手順を追記

### 新機能（#73）の反映
- 「ページからDOI取得」ボタン（Chrome拡張版のみ）: README の概要・Chrome拡張版機能リスト・機能比較表・使い方、user_guide の STEP 1 に追加
- 助成情報検索のDOI入力→課題番号自動取得（両版で利用可）: README の機能比較表・利用方法に追加

### 表現改善・その他
- README「現在のバージョン（Phase 1）では…」を Phase 2 完了後の現状（プレビュー・複数DOI一括TSV出力を含む）に更新
- README ディレクトリ構成に `shared.js` / `tsv_headers_template.js`（ルート・chrome-extension 双方）、`opensearch_panel.html` / `opensearch_panel.js`、`icons/` を追加
- user_guide の `/api-flow.md` リンクを相対パス `../api-flow.md` に修正
- README 変更履歴・docs/worklog.md に今回のエントリを追記

## 対象外（不要と判断）
- LOCAL_VERSION / manifest.json / テスト用ファイル / E2Eテスト: HTML・JSのコード変更がないため不要
- README「最新の更新」テーブル: ツール本体の変更ではないため更新せず

🤖 Generated with [Claude Code](https://claude.com/claude-code)