### PR TITLE
feat: 管理フィールド・リポジトリURLの初期値設定 + ページからのDOI取得をJSON-LD対応に拡張 (#148, #159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,17 @@ APIからのデータ取得・マッピング・編集UI・プレビュー・TSV
 - 検索結果はタイトル・著者・書誌情報・ファイルリンクとともに一覧表示され、クリックで詳細フィールドを展開できます。
 - 設定ページでデフォルトのリポジトリURLを登録しておくと、タブを開いた際に自動入力されます。
 
-### API Key の設定
+### 設定（APIキー・初期値）
+
+APIキーと、TSV出力時の管理（システム）フィールド・リポジトリURLの初期値は、いずれも **Chrome拡張機能版は設定ページ**、**通常ブラウザ版は `shared.js` の `CONFIG` 定数** で設定します。APIキー・初期値ともすべて任意です（未設定でも動作します）。
+
+設定できる初期値（任意）:
+
+| 項目 | 説明 |
+|------|------|
+| `.IndexID[0]`（登録先インデックスID） | アイテムの登録先インデックスID（例: `1697430475875`） |
+| `.POS_INDEX[0]`（インデックス名パス） | 人間可読のインデックス名パス（例: `学術雑誌論文`） |
+| リポジトリURL | TSV出力時にスキーマURLの `https://localhost/` を置換するリポジトリのURL |
 
 #### Chrome拡張機能版（推奨）
 
@@ -187,9 +197,11 @@ Chrome拡張機能版では設定ページでAPIキーをまとめて設定で�
 
 CORS非対応のAPI（KAKEN XML API・JaLC API・Open Policy Finder API）が Chrome拡張機能のService Worker経由で利用可能になります。
 
+管理フィールド・リポジトリURLの初期値も同じ設定ページで指定できます。`.IndexID[0]` と `.POS_INDEX[0]` は「TSV 管理フィールドの初期値」で設定し、リポジトリURLは「JAIRO Cloud OpenSearch」の「デフォルトリポジトリ URL」と共用されます（OpenSearch検索タブとTSV生成ツールの両方に反映されます）。
+
 #### 通常ブラウザ版
 
-`shared.js` をテキストエディタで開き、`CONFIG` 定数にAPIキーを設定してください。この設定は `make_jc_importer.html` と `funder_lookup.html` の両方に反映されます。
+`shared.js` をテキストエディタで開き、`CONFIG` 定数にAPIキーと初期値をまとめて設定してください。この設定は `make_jc_importer.html` と `funder_lookup.html` の両方に反映されます。初期値（`DEFAULT_*`）は空欄のままでも動作します。
 
 ```js
 const CONFIG = {
@@ -203,8 +215,22 @@ const CONFIG = {
 
     // Open Policy Finder APIキー（任意・Chrome拡張機能版のみ有効）
     OPF_API_KEY: "YOUR_OPF_API_KEY",
+
+    // ===== システム（管理フィールド）・リポジトリURLの初期値（任意） =====
+    // よく使う登録先インデックスやリポジトリURLを設定すると、フォームに初期値として入力されます。
+
+    // リポジトリURL（repo-host）。TSVのスキーマURL置換に使用
+    DEFAULT_REPOSITORY_URL: "",
+
+    // .IndexID[0]（.metadata.path[0]）アイテムの登録先インデックスID  例: 1697430475875
+    DEFAULT_INDEX_ID: "",
+
+    // .POS_INDEX[0]（.pos_index[0]）インデックス名パス（人間可読）  例: 学術雑誌論文
+    DEFAULT_POS_INDEX: "",
 };
 ```
+
+`DEFAULT_*` に設定した値は、「データ取得」後や「空値で全フィールド表示」時に管理フィールドの初期値として入力され、リポジトリURLは入力欄が空のときに自動入力されます。
 
 #### OpenAlex API Key（推奨）
 
@@ -222,44 +248,6 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 - JSPS（日本学術振興会）が助成機関に含まれる場合に、CiNii Research Projects API を通じて科研費の課題名（日英）とKAKEN課題ページURLを自動取得
 - ISSNをもとにCiNii Research OpenSearch APIからNCID（NACSIS-CAT書誌ID）を自動取得
-
-### 管理フィールド・リポジトリURLの初期値設定（任意）
-
-同じリポジトリへ繰り返しインポートする場合、TSVの管理（システム）フィールドの初期値を事前に設定しておくと、毎回の入力を省けます。設定できる項目は以下の3つです。
-
-| 項目 | 説明 |
-|------|------|
-| `.IndexID[0]`（登録先インデックスID） | アイテムの登録先インデックスID（例: `1697430475875`） |
-| `.POS_INDEX[0]`（インデックス名パス） | 人間可読のインデックス名パス（例: `学術雑誌論文`） |
-| リポジトリURL | TSV出力時にスキーマURLの `https://localhost/` を置換するリポジトリのURL |
-
-#### Chrome拡張機能版
-
-設定ページ（`chrome://extensions` → 詳細 → 拡張機能のオプション）の「TSV 管理フィールドの初期値」で `.IndexID[0]` と `.POS_INDEX[0]` を設定できます。リポジトリURLは「JAIRO Cloud OpenSearch」の「デフォルトリポジトリ URL」と共用されます（OpenSearch検索タブとTSV生成ツールの両方に反映されます）。
-
-#### 通常ブラウザ版
-
-`shared.js` をテキストエディタで開き、`CONFIG` 定数の以下の項目を設定してください（空欄のままでも動作します）。
-
-```js
-const CONFIG = {
-    // ... APIキーの設定 ...
-
-    // ===== システム（管理フィールド）・リポジトリURLの初期値（任意） =====
-    // よく使う登録先インデックスやリポジトリURLを設定すると、フォームに初期値として入力されます。
-
-    // リポジトリURL（repo-host）。TSVのスキーマURL置換に使用
-    DEFAULT_REPOSITORY_URL: "",
-
-    // .IndexID[0]（.metadata.path[0]）アイテムの登録先インデックスID  例: 1697430475875
-    DEFAULT_INDEX_ID: "",
-
-    // .POS_INDEX[0]（.pos_index[0]）インデックス名パス（人間可読）  例: 学術雑誌論文
-    DEFAULT_POS_INDEX: "",
-};
-```
-
-設定した値は、「データ取得」後や「空値で全フィールド表示」時に管理フィールドの初期値として入力され、リポジトリURLは入力欄が空のときに自動入力されます。
 
 ## ディレクトリ構成
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張機能版 | 2026-06-11 | ver. 1.10.1 | 助成情報検索でマルチバイト文字列（日本語）を含む行から課題番号を抽出できないバグを修正（[#149](https://github.com/tzhaya/jc-import-file-maker/issues/149)）。検索結果の外部リンクをクリックするとサイドパネルがリロードされる不具合を修正（[#150](https://github.com/tzhaya/jc-import-file-maker/issues/150)） |
-| インポート用TSV生成ツール | 2026-06-06 | — | IndexID・公開日がTSVに出力されないバグ修正（[#142](https://github.com/tzhaya/jc-import-file-maker/issues/142)）、管理フィールドのIndexID/POS_INDEX候補値ヒント誤りを修正（[#143](https://github.com/tzhaya/jc-import-file-maker/issues/143)） |
+| Chrome拡張機能版 | 2026-06-15 | ver. 1.11.0 | TSV管理フィールド（`.IndexID[0]` / `.POS_INDEX[0]`）とリポジトリURLの初期値を設定画面で定義可能に（[#148](https://github.com/tzhaya/jc-import-file-maker/issues/148)）。ページからのDOI自動取得をJSON-LD（schema.org `ScholarlyArticle`）対応に拡張（[#159](https://github.com/tzhaya/jc-import-file-maker/issues/159)） |
+| インポート用TSV生成ツール | 2026-06-15 | — | TSV管理フィールド（`.IndexID[0]` / `.POS_INDEX[0]`）とリポジトリURLの初期値を `shared.js` で定義可能に（[#148](https://github.com/tzhaya/jc-import-file-maker/issues/148)） |
 | 助成情報検索ツール | 2026-06-11 | — | マルチバイト文字列（日本語）を含む行から課題番号を抽出できないバグを修正（[#149](https://github.com/tzhaya/jc-import-file-maker/issues/149)）。検索結果の外部リンクをクリックするとツールがリロードされる不具合を修正（[#150](https://github.com/tzhaya/jc-import-file-maker/issues/150)） |
 
 ## 導入方法
@@ -223,6 +223,44 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 - JSPS（日本学術振興会）が助成機関に含まれる場合に、CiNii Research Projects API を通じて科研費の課題名（日英）とKAKEN課題ページURLを自動取得
 - ISSNをもとにCiNii Research OpenSearch APIからNCID（NACSIS-CAT書誌ID）を自動取得
 
+### 管理フィールド・リポジトリURLの初期値設定（任意）
+
+同じリポジトリへ繰り返しインポートする場合、TSVの管理（システム）フィールドの初期値を事前に設定しておくと、毎回の入力を省けます。設定できる項目は以下の3つです。
+
+| 項目 | 説明 |
+|------|------|
+| `.IndexID[0]`（登録先インデックスID） | アイテムの登録先インデックスID（例: `1697430475875`） |
+| `.POS_INDEX[0]`（インデックス名パス） | 人間可読のインデックス名パス（例: `学術雑誌論文`） |
+| リポジトリURL | TSV出力時にスキーマURLの `https://localhost/` を置換するリポジトリのURL |
+
+#### Chrome拡張機能版
+
+設定ページ（`chrome://extensions` → 詳細 → 拡張機能のオプション）の「TSV 管理フィールドの初期値」で `.IndexID[0]` と `.POS_INDEX[0]` を設定できます。リポジトリURLは「JAIRO Cloud OpenSearch」の「デフォルトリポジトリ URL」と共用されます（OpenSearch検索タブとTSV生成ツールの両方に反映されます）。
+
+#### 通常ブラウザ版
+
+`shared.js` をテキストエディタで開き、`CONFIG` 定数の以下の項目を設定してください（空欄のままでも動作します）。
+
+```js
+const CONFIG = {
+    // ... APIキーの設定 ...
+
+    // ===== システム（管理フィールド）・リポジトリURLの初期値（任意） =====
+    // よく使う登録先インデックスやリポジトリURLを設定すると、フォームに初期値として入力されます。
+
+    // リポジトリURL（repo-host）。TSVのスキーマURL置換に使用
+    DEFAULT_REPOSITORY_URL: "",
+
+    // .IndexID[0]（.metadata.path[0]）アイテムの登録先インデックスID  例: 1697430475875
+    DEFAULT_INDEX_ID: "",
+
+    // .POS_INDEX[0]（.pos_index[0]）インデックス名パス（人間可読）  例: 学術雑誌論文
+    DEFAULT_POS_INDEX: "",
+};
+```
+
+設定した値は、「データ取得」後や「空値で全フィールド表示」時に管理フィールドの初期値として入力され、リポジトリURLは入力欄が空のときに自動入力されます。
+
 ## ディレクトリ構成
 
 ```
@@ -289,7 +327,8 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
-| 2026-06-11 | 助成情報検索ツールの課題番号抽出を修正：マルチバイト文字列（日本語）を含む行を1つの課題番号として誤取り込みするバグを修正し、課題番号として妥当な文字のみの行を判定対象とするよう変更。区切り文字に全角「、，；」を追加（[#149](https://github.com/tzhaya/jc-import-file-maker/issues/149)）。検索結果の外部リンクをクリックするとサイドパネルが既定ページにリセットされる不具合を修正（`chrome.tabs.create` で新しいタブを開く、[#150](https://github.com/tzhaya/jc-import-file-maker/issues/150)）。manifest version `1.10.0` → `1.10.1` |
+| 2026-06-15 | TSV管理フィールドの初期値を設定可能に：`.IndexID[0]`（登録先インデックスID）・`.POS_INDEX[0]`（インデックス名パス）とリポジトリURLの初期値を、スタンドアロン版は `shared.js` の `CONFIG`、Chrome拡張版は設定画面（`options.html`）で定義できるよう対応。リポジトリURLはChrome拡張ではOpenSearch検索の既定値と共用（[#148](https://github.com/tzhaya/jc-import-file-maker/issues/148)） |
+| 2026-06-15 | 電子ジャーナルページからのDOI自動取得（[#73](https://github.com/tzhaya/jc-import-file-maker/issues/73)）をJSON-LD対応に拡張：metaタグでDOIを取得できない場合、`<script type="application/ld+json">` 内の schema.org `ScholarlyArticle` の `identifier`（文字列／`PropertyValue` 形式、`@graph` 入れ子に対応）をフォールバックとして採用（[#159](https://github.com/tzhaya/jc-import-file-maker/issues/159)）。manifest version `1.10.1` → `1.11.0` |
 | 2026-06-10 | ドキュメント整合性修正：README・使い方ガイドを現在の実装に同期（#73新機能の反映、`shared.js`/`tsv_headers_template.js` 依存の明記、TSV出力ファイル名の記述修正、機能比較表・ディレクトリ構成の更新） |
 | 2026-06-10 | 電子ジャーナルページのmetaタグ（`citation_doi`, `prism.doi`, `DOI`, `dc.identifier`）からDOIを自動取得するボタンをDOIインポートタブに追加。助成情報検索タブにDOI入力欄を新設し、Crossref/OpenAlex APIから課題番号を自動抽出してテキストエリアへ流し込む機能を追加（[#73](https://github.com/tzhaya/jc-import-file-maker/issues/73)）。manifest version `1.9.5` → `1.10.0` |
 | 2026-06-06 | IndexID・公開日がTSVに出力されないバグを修正：`groupTsvColumns()` 内 `.metadata.path[0]` / `.metadata.pubdate` が `__other__` に分類されTSVスキップされていた問題を `__system__` に変更して解消（[#142](https://github.com/tzhaya/jc-import-file-maker/issues/142)）。管理フィールドのIndexID/POS_INDEX候補値ヒント誤り（入れ違い）を修正（[#143](https://github.com/tzhaya/jc-import-file-maker/issues/143)）。manifest version `1.9.4` → `1.9.5` |

--- a/chrome-extension/funder_lookup.js
+++ b/chrome-extension/funder_lookup.js
@@ -42,6 +42,8 @@ async function getDoiFromCurrentTab() {
     const results = await chrome.scripting.executeScript({
       target: { tabId: tab.id },
       func: () => {
+        // func はページコンテキストへシリアライズされ外部スコープを参照できないため、ロジックを自己完結させる
+        const DOI_GUARD = /^(doi:|https?:\/\/(dx\.)?doi\.org\/|10\.\d{4,9}\/)/i;
         const selectors = [
           'meta[name="citation_doi" i]',
           'meta[name="prism.doi" i]',
@@ -53,14 +55,62 @@ async function getDoiFromCurrentTab() {
         }
         // dc.identifier はDOI形式（doi: / doi.org / 素の 10.xxxx）のみ採用
         const dcId = document.querySelector('meta[name="dc.identifier" i]');
-        if (dcId?.content && /^(doi:|https?:\/\/(dx\.)?doi\.org\/|10\.\d{4,9}\/)/i.test(dcId.content)) {
+        if (dcId?.content && DOI_GUARD.test(dcId.content)) {
           return dcId.content.trim();
+        }
+        // JSON-LD（schema.org ScholarlyArticle）の identifier をフォールバックとして採用
+        const isSchemaOrg = (ctx) => {
+          if (!ctx) return false;
+          const vals = Array.isArray(ctx) ? ctx : [ctx];
+          return vals.some(v => typeof v === 'string' && /^https?:\/\/schema\.org\/?$/i.test(v.trim()));
+        };
+        const hasType = (t, target) => {
+          const arr = Array.isArray(t) ? t : [t];
+          return arr.some(x => typeof x === 'string' && x.toLowerCase() === target.toLowerCase());
+        };
+        // identifier（文字列 / PropertyValue / それらの配列）から最初のDOI文字列を取り出す
+        const extractIdentifier = (idf) => {
+          const items = Array.isArray(idf) ? idf : [idf];
+          for (const it of items) {
+            if (typeof it === 'string' && DOI_GUARD.test(it.trim())) return it.trim();
+            if (it && typeof it === 'object') {
+              const v = it.value ?? it['@value'];
+              if (typeof v === 'string' && DOI_GUARD.test(v.trim())) return v.trim();
+            }
+          }
+          return null;
+        };
+        // @graph 入れ子も平坦化して全ノードを収集
+        const collect = (node, out) => {
+          if (!node) return;
+          if (Array.isArray(node)) { node.forEach(n => collect(n, out)); return; }
+          if (typeof node === 'object') {
+            out.push(node);
+            if (node['@graph']) collect(node['@graph'], out);
+          }
+        };
+        const blocks = document.querySelectorAll('script[type="application/ld+json" i]');
+        for (const block of blocks) {
+          let data;
+          try { data = JSON.parse(block.textContent); } catch { continue; }
+          const roots = Array.isArray(data) ? data : [data];
+          for (const root of roots) {
+            if (!root || typeof root !== 'object' || !isSchemaOrg(root['@context'])) continue;
+            const nodes = [];
+            collect(root, nodes);
+            for (const n of nodes) {
+              if (hasType(n['@type'], 'ScholarlyArticle')) {
+                const found = extractIdentifier(n.identifier);
+                if (found) return found;
+              }
+            }
+          }
         }
         return null;
       },
     });
     const raw = results?.[0]?.result ?? null;
-    if (!raw) return { error: 'このページからDOIを取得できませんでした（DOIのmetaタグが見つかりません）。' };
+    if (!raw) return { error: 'このページからDOIを取得できませんでした（DOIのmetaタグ・JSON-LDが見つかりません）。' };
     const doi = normalizeDoi(raw);
     if (!isValidDoi(doi)) return { error: 'このページのDOIを正しく認識できませんでした。' };
     return { doi };
@@ -752,7 +802,7 @@ async function copyTsvToClipboard(btn) {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-06-11';
+  const LOCAL_VERSION = '2026-06-15';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=funder_lookup.html&per_page=1');
     if (!res.ok) return;

--- a/chrome-extension/funder_panel.html
+++ b/chrome-extension/funder_panel.html
@@ -237,7 +237,7 @@
 </nav>
 <h1>助成情報検索ツール</h1>
 <p style="font-size:0.82em; color:#555; margin:4px 0 12px;">
-  最終更新: 2026-06-11 &nbsp;|&nbsp;
+  最終更新: 2026-06-15 &nbsp;|&nbsp;
   <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#555;">github.com/tzhaya/jc-import-file-maker</a>
   <span id="update-check"></span>
 </p>

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -684,8 +684,8 @@ function renderSystemFields(systemData) {
   const sysRows = [
     { label: '.id',                  hint: '新規登録時は空欄', key: 'sys_id',      type: 'text',   default: '' },
     { label: '.uri',                 hint: '新規登録時は空欄', key: 'sys_uri',     type: 'text',   default: '' },
-    { label: '.IndexID[0]',          hint: '1697430475875',     key: 'sys_path',  type: 'text',   default: '' },
-    { label: '.POS_INDEX[0]',        hint: '学術雑誌論文',          key: 'sys_pos', type: 'text',   default: '' },
+    { label: '.IndexID[0]',          hint: '1697430475875',     key: 'sys_path',  type: 'text',   default: CONFIG.DEFAULT_INDEX_ID || '' },
+    { label: '.POS_INDEX[0]',        hint: '学術雑誌論文',          key: 'sys_pos', type: 'text',   default: CONFIG.DEFAULT_POS_INDEX || '' },
     { label: '.PUBLISH_STATUS',      hint: 'private / public', key: 'sys_status',  type: 'select', options: ['private','public'], default: 'private' },
     { label: '.FEEDBACK_MAIL[0]',    hint: '',                  key: 'sys_mail',   type: 'text',   default: '' },
     { label: '.RESEAECHMAP_LINKAGE', hint: '',                  key: 'sys_researchmap', type: 'text', default: '' },
@@ -771,6 +771,8 @@ async function getDoiFromCurrentTab() {
     const results = await chrome.scripting.executeScript({
       target: { tabId: tab.id },
       func: () => {
+        // func はページコンテキストへシリアライズされ外部スコープを参照できないため、ロジックを自己完結させる
+        const DOI_GUARD = /^(doi:|https?:\/\/(dx\.)?doi\.org\/|10\.\d{4,9}\/)/i;
         const selectors = [
           'meta[name="citation_doi" i]',
           'meta[name="prism.doi" i]',
@@ -782,14 +784,62 @@ async function getDoiFromCurrentTab() {
         }
         // dc.identifier はDOI形式（doi: / doi.org / 素の 10.xxxx）のみ採用
         const dcId = document.querySelector('meta[name="dc.identifier" i]');
-        if (dcId?.content && /^(doi:|https?:\/\/(dx\.)?doi\.org\/|10\.\d{4,9}\/)/i.test(dcId.content)) {
+        if (dcId?.content && DOI_GUARD.test(dcId.content)) {
           return dcId.content.trim();
+        }
+        // JSON-LD（schema.org ScholarlyArticle）の identifier をフォールバックとして採用
+        const isSchemaOrg = (ctx) => {
+          if (!ctx) return false;
+          const vals = Array.isArray(ctx) ? ctx : [ctx];
+          return vals.some(v => typeof v === 'string' && /^https?:\/\/schema\.org\/?$/i.test(v.trim()));
+        };
+        const hasType = (t, target) => {
+          const arr = Array.isArray(t) ? t : [t];
+          return arr.some(x => typeof x === 'string' && x.toLowerCase() === target.toLowerCase());
+        };
+        // identifier（文字列 / PropertyValue / それらの配列）から最初のDOI文字列を取り出す
+        const extractIdentifier = (idf) => {
+          const items = Array.isArray(idf) ? idf : [idf];
+          for (const it of items) {
+            if (typeof it === 'string' && DOI_GUARD.test(it.trim())) return it.trim();
+            if (it && typeof it === 'object') {
+              const v = it.value ?? it['@value'];
+              if (typeof v === 'string' && DOI_GUARD.test(v.trim())) return v.trim();
+            }
+          }
+          return null;
+        };
+        // @graph 入れ子も平坦化して全ノードを収集
+        const collect = (node, out) => {
+          if (!node) return;
+          if (Array.isArray(node)) { node.forEach(n => collect(n, out)); return; }
+          if (typeof node === 'object') {
+            out.push(node);
+            if (node['@graph']) collect(node['@graph'], out);
+          }
+        };
+        const blocks = document.querySelectorAll('script[type="application/ld+json" i]');
+        for (const block of blocks) {
+          let data;
+          try { data = JSON.parse(block.textContent); } catch { continue; }
+          const roots = Array.isArray(data) ? data : [data];
+          for (const root of roots) {
+            if (!root || typeof root !== 'object' || !isSchemaOrg(root['@context'])) continue;
+            const nodes = [];
+            collect(root, nodes);
+            for (const n of nodes) {
+              if (hasType(n['@type'], 'ScholarlyArticle')) {
+                const found = extractIdentifier(n.identifier);
+                if (found) return found;
+              }
+            }
+          }
         }
         return null;
       },
     });
     const raw = results?.[0]?.result ?? null;
-    if (!raw) return { error: 'このページからDOIを取得できませんでした（DOIのmetaタグが見つかりません）。' };
+    if (!raw) return { error: 'このページからDOIを取得できませんでした（DOIのmetaタグ・JSON-LDが見つかりません）。' };
     const doi = normalizeDoi(raw);
     if (!isValidDoi(doi)) return { error: 'このページのDOIを正しく認識できませんでした。' };
     return { doi };
@@ -2062,8 +2112,8 @@ async function mapToItemType(crJson, oaJson, rorMap) {
     system: {
       id:             '',
       uri:            '',
-      path:           '',
-      pos_index:      '',
+      path:           CONFIG.DEFAULT_INDEX_ID || '',
+      pos_index:      CONFIG.DEFAULT_POS_INDEX || '',
       publish_status: 'private',
       feedback_mail:  '',
       researchmap_linkage: '',
@@ -2528,7 +2578,7 @@ async function mapToItemTypeJaLC(jalcJson) {
   // ===== メタデータオブジェクト =====
   const metadata = {
     system: {
-      id: '', uri: '', path: '', pos_index: '',
+      id: '', uri: '', path: CONFIG.DEFAULT_INDEX_ID || '', pos_index: CONFIG.DEFAULT_POS_INDEX || '',
       publish_status: 'private', feedback_mail: '', researchmap_linkage: '',
       cnri: '', doi_ra: '', doi: '',
       edit_mode: 'Keep', pubdate: todayStr(),
@@ -4724,8 +4774,8 @@ function buildMaxSizeMetadata(metadataArray) {
 function buildEmptyMetadata() {
   return {
     system: {
-      id: '', uri: '', path: '',
-      pos_index: '',
+      id: '', uri: '', path: CONFIG.DEFAULT_INDEX_ID || '',
+      pos_index: CONFIG.DEFAULT_POS_INDEX || '',
       publish_status: 'private', feedback_mail: '', researchmap_linkage: '', cnri: '',
       doi_ra: '', doi: '', edit_mode: 'Keep', pubdate: todayStr(),
     },
@@ -5989,6 +6039,12 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
     document.getElementById('cinii-apikey-warning').style.display = 'block';
   }
 
+  // リポジトリURL初期値（未入力時のみ。Chrome拡張は OpenSearch の既定値と共用）
+  const repoHostInput = document.getElementById('repo-host');
+  if (repoHostInput && !repoHostInput.value && CONFIG.DEFAULT_REPOSITORY_URL) {
+    repoHostInput.value = CONFIG.DEFAULT_REPOSITORY_URL;
+  }
+
   // ボタンイベント登録（MV3 CSP対応: inline onclick は使用不可）
   document.getElementById('get-doi-from-page').addEventListener('click', async (e) => {
     const btn = e.currentTarget;
@@ -6039,7 +6095,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-06-10';
+  const LOCAL_VERSION = '2026-06-15';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "JAIRO Cloud（WEKO3）に登録するメタデータの作成とインポートを支援するChrome拡張機能です。DOIを入力するだけで、Crossref / JaLC / OpenAlex から書誌メタデータを自動で取得します。",
   "icons": {
     "16": "icons/icon16.png",

--- a/chrome-extension/options.html
+++ b/chrome-extension/options.html
@@ -103,7 +103,22 @@
     <div class="field">
       <label for="default-repo-url">デフォルトリポジトリ URL</label>
       <input type="text" id="default-repo-url" placeholder="https://example.repo.nii.ac.jp/">
-      <p class="hint">OpenSearch検索タブを開いたときに自動入力されるリポジトリのURLを設定します。</p>
+      <p class="hint">OpenSearch検索タブを開いたときに自動入力されるリポジトリのURLを設定します。
+        TSV生成ツールの「リポジトリURL」初期値としても共用されます。</p>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>TSV 管理フィールドの初期値</h2>
+    <div class="field">
+      <label for="default-index-id">.IndexID[0]（登録先インデックスID）</label>
+      <input type="text" id="default-index-id" placeholder="例: 1697430475875">
+      <p class="hint">TSV生成ツールでアイテムの登録先インデックスIDの初期値として入力されます。</p>
+    </div>
+    <div class="field">
+      <label for="default-pos-index">.POS_INDEX[0]（インデックス名パス）</label>
+      <input type="text" id="default-pos-index" placeholder="例: 学術雑誌論文">
+      <p class="hint">インデックス名パス（人間可読）の初期値として入力されます。</p>
     </div>
   </div>
 

--- a/chrome-extension/options.js
+++ b/chrome-extension/options.js
@@ -1,6 +1,8 @@
-const keys = ['defaultRepositoryUrl', 'OpenAlex_API_KEY', 'CiNii_API_KEY', 'OPF_API_KEY'];
+const keys = ['defaultRepositoryUrl', 'defaultIndexId', 'defaultPosIndex', 'OpenAlex_API_KEY', 'CiNii_API_KEY', 'OPF_API_KEY'];
 const inputs = {
   defaultRepositoryUrl: document.getElementById('default-repo-url'),
+  defaultIndexId:       document.getElementById('default-index-id'),
+  defaultPosIndex:      document.getElementById('default-pos-index'),
   OpenAlex_API_KEY:     document.getElementById('openalex-key'),
   CiNii_API_KEY:        document.getElementById('cinii-key'),
   OPF_API_KEY:          document.getElementById('opf-key'),

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -500,7 +500,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-06-10 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-06-15 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -512,6 +512,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-15</td>
+        <td style="padding:2px 0;">Chrome拡張 ver. 1.11.0：TSV管理フィールド（.IndexID[0]/.POS_INDEX[0]）とリポジトリURLの初期値を設定画面で定義可能に（#148）。ページからのDOI自動取得をJSON-LD（schema.org ScholarlyArticle）対応に拡張（#159）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-10</td>
         <td style="padding:2px 0;">Chrome拡張 ver. 1.10.0：電子ジャーナルページのmetaタグからDOIを自動取得するボタンを追加（#73）。助成情報検索タブにDOI入力欄とCrossref/OpenAlex経由の課題番号自動取得機能を追加</td>
@@ -527,14 +531,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-14</td>
         <td style="padding:2px 0;">Chrome拡張 ver. 1.9.3：ストア公開名と一致するようツール名を「JAIRO Cloud インポート支援ツール」に統一（#138, #139）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-13</td>
-        <td style="padding:2px 0;">Chrome拡張 ver. 1.9.2：Chromeウェブストア登録準備 - 拡張機能アイコン追加 + プライバシーポリシー策定（#112）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-29</td>
-        <td style="padding:2px 0;">CONFIG共通化：APIキー設定とChrome拡張ユーティリティをshared.jsに外部化、TSVテンプレートをtsv_headers_template.jsに外部化（#111）</td>
       </tr>
     </tbody>
   </table>

--- a/chrome-extension/shared.js
+++ b/chrome-extension/shared.js
@@ -13,16 +13,37 @@ const CONFIG = {
     // Open Policy Finder APIキー（任意・Chrome拡張版のみ有効）
     // https://openpolicyfinder.jisc.ac.uk/ で取得できます
     OPF_API_KEY: "YOUR_OPF_API_KEY",
+
+    // ===== システム（管理フィールド）・リポジトリURLの初期値（任意） =====
+    // よく使う登録先インデックスやリポジトリURLを設定すると、フォームに初期値として入力されます。
+    // Chrome拡張版では options.html で設定できます（このファイルの編集は不要です）。
+
+    // リポジトリURL（repo-host）。TSVのスキーマURL置換に使用
+    // Chrome拡張版では OpenSearch の「デフォルトリポジトリ URL」と共用します
+    DEFAULT_REPOSITORY_URL: "",
+
+    // .IndexID[0]（.metadata.path[0]）アイテムの登録先インデックスID  例: 1697430475875
+    DEFAULT_INDEX_ID: "",
+
+    // .POS_INDEX[0]（.pos_index[0]）インデックス名パス（人間可読）  例: 学術雑誌論文
+    DEFAULT_POS_INDEX: "",
 };
 
 // ===== Chrome拡張: chrome.storage.local からAPIキーを読み込む =====
 async function loadConfig() {
   if (typeof chrome === 'undefined' || !chrome.storage) return;
   try {
-    const stored = await chrome.storage.local.get(['OpenAlex_API_KEY', 'CiNii_API_KEY', 'OPF_API_KEY']);
+    const stored = await chrome.storage.local.get([
+      'OpenAlex_API_KEY', 'CiNii_API_KEY', 'OPF_API_KEY',
+      'defaultRepositoryUrl', 'defaultIndexId', 'defaultPosIndex',
+    ]);
     if (stored.OpenAlex_API_KEY) CONFIG.OpenAlex_API_KEY = stored.OpenAlex_API_KEY;
     if (stored.CiNii_API_KEY)    CONFIG.CiNii_API_KEY    = stored.CiNii_API_KEY;
     if (stored.OPF_API_KEY)      CONFIG.OPF_API_KEY      = stored.OPF_API_KEY;
+    // システム（管理フィールド）・リポジトリURLの初期値（リポジトリURLは OpenSearch の既定値と共用）
+    if (stored.defaultRepositoryUrl) CONFIG.DEFAULT_REPOSITORY_URL = stored.defaultRepositoryUrl;
+    if (stored.defaultIndexId)       CONFIG.DEFAULT_INDEX_ID       = stored.defaultIndexId;
+    if (stored.defaultPosIndex)      CONFIG.DEFAULT_POS_INDEX      = stored.defaultPosIndex;
   } catch { /* 拡張外環境では無視 */ }
 }
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -216,7 +216,7 @@ make_jc_importer.html
     -   カスタムテンプレート完全パース（Phase 2-B）: ユーザが5行ヘッダー（ItemType行・キー行・ラベル行・System行・制約行）を貼り付けた場合、`TSV_HEADERS_TEMPLATE` を丸ごと上書きしてTSV出力に反映する。不足行はデフォルトから補完。`parseCustomTemplate()` がパースを担当し、`groupTsvColumns()` / `buildTsvColumnDefs()` に template 引数として渡す
     -   ItemType行の自動設定（Phase 2-D）: TSV 1行目のアイテムタイプ名・スキーマURLをデフォルト値（「デフォルトアイテムタイプ（フル）(30002)」/ `https://localhost/items/jsonschema/30002`）で自動設定。カスタムテンプレート使用時はその row0 をそのまま使用
     -   複数DOI一括TSV出力（Phase 2-C）: DOIを連続取得して `allMetadata[]` 配列に蓄積し、ヘッダー5行 + データN行の一括TSVを出力する。列数は全metadataの配列フィールド最大長で展開（`buildMaxSizeMetadata()`）。バッチ管理パネルで蓄積件数表示・個別削除・全クリア・アイテム切替が可能
-    -   リポジトリURL入力: `#repo-host` 入力欄でスキーマURLの `https://localhost/` を実際のリポジトリホスト名に置換
+    -   リポジトリURL入力: `#repo-host` 入力欄でスキーマURLの `https://localhost/` を実際のリポジトリホスト名に置換。初期値は設定で定義可能（[issue #148](https://github.com/tzhaya/jc-import-file-maker/issues/148)、後述「管理フィールド・リポジトリURLの初期値設定」）
     -   ファイル名: 単一DOIは `{DOI}.tsv`、複数DOIは `import_YYYYMMDD_HHMMSS.tsv`
     -   空フィールド省略: 値が存在しないフィールドの列群はTSVに出力しない
     -   除外フィールド: apc5, heading36, dissertation30〜degree33, item_1698624001〜010 は常に除外
@@ -226,6 +226,7 @@ make_jc_importer.html
     -   DOIインポートタブに「ページからDOI取得」ボタンを追加し、現在表示中のページのmetaタグからDOIを自動検出してDOI入力欄にセットする
     -   metaタグの優先順位: `meta[name="citation_doi"]` → `meta[name="prism.doi"]` → `meta[name="DOI"]` → `meta[name="dc.identifier"]`（DOI形式のみ）。`name` 属性は大文字小文字を区別しない（CSSセレクタの `i` フラグ）
     -   `dc.identifier` は `doi:` / `https://doi.org/` / `https://dx.doi.org/` / 素の `10.xxxx/` で始まる場合のみ採用（ISBN・ISSN等との混在対策）
+    -   JSON-LDフォールバック（[issue #159](https://github.com/tzhaya/jc-import-file-maker/issues/159)）: 上記metaタグでDOIを取得できない場合、`<script type="application/ld+json">` 内の `@context` が schema.org（`http(s)://schema.org`）かつ `@type` に `ScholarlyArticle` を含むノードの `identifier` をDOIとして採用する。`@graph` 入れ子・トップレベル配列を平坦化して走査し、`identifier` は文字列・schema.org `PropertyValue`（`{ value: ... }`）形式・それらの配列に対応。採用は `dc.identifier` と同じDOI形式ガードを通過した値のみ（Taylor & Francis 等、metaタグにDOIを持たないページへの対応）
     -   取得したDOIは `normalizeDoi()` で正規化（`https://(dx.)doi.org/` プレフィックス・`doi:` プレフィックスを除去）し、`isValidDoi()`（`^10.\d{4,9}/\S+$`・256文字以内）で形式検証してから入力欄にセット。検証に失敗した場合はエラーメッセージを表示
     -   `chrome.scripting.executeScript()` を使用。`chrome://` 等の特権ページでは実行不可のためtry-catchでエラーを吸収し、`console.warn()` でログ出力
     -   権限: `scripting` + `optional_host_permissions`（`http(s)://*/*`）。`activeTab` はサイドパネル内ボタンからの遷移後に失効するため使用しない。ボタン押下時の**最初の `await`** で `chrome.permissions.request({ origins: ['https://*/*','http://*/*'] })` を呼び、ウェブサイトへのアクセス許可を1回だけ要求する（初回のみ許可ダイアログ、許可後は再確認不要・全サイトで動作）。この設計により、(1) ユーザージェスチャーが失効しない、(2) 権限付与後に `chrome.tabs.query()` が `tab.url` を返すようになる（未付与時は `tabs`/host 権限がないため `tab.url` が `undefined` になる仕様）の2点を同時に解決する
@@ -261,6 +262,12 @@ make_jc_importer.html
     -   ページング: 1ページ20件固定、前へ/次へボタンで移動
     -   Service Worker経由のfetchラッパー（CORS回避）を使用
     -   `options.html` にデフォルトリポジトリURL設定欄を追加。`chrome.storage.local` の `defaultRepositoryUrl` に保存し、タブ開放時に自動入力する
+
+-   **管理フィールド・リポジトリURLの初期値設定**（[issue #148](https://github.com/tzhaya/jc-import-file-maker/issues/148)）:
+    -   TSV管理（システム）フィールド `.IndexID[0]`（`.metadata.path[0]`、登録先インデックスID）・`.POS_INDEX[0]`（`.pos_index[0]`、インデックス名パス）、およびリポジトリURL（`#repo-host`）の初期値を定義できる
+    -   スタンドアロン版: `shared.js` の `CONFIG`（`DEFAULT_INDEX_ID` / `DEFAULT_POS_INDEX` / `DEFAULT_REPOSITORY_URL`）を編集して定義
+    -   Chrome拡張版: `options.html` の設定画面で定義し `chrome.storage.local`（`defaultIndexId` / `defaultPosIndex`）に保存。リポジトリURLは OpenSearch 検索のデフォルト値（`defaultRepositoryUrl`）と共用する
+    -   `loadConfig()` が `chrome.storage.local` から `CONFIG` へ反映し、`renderSystemFields()`（管理フィールドの初期表示値）・`buildEmptyMetadata()` / `mapToItemType()` / `mapToItemTypeJaLC()`（メタデータ初期値）・`init()`（`#repo-host` のプリフィル、未入力時のみ）に適用する
 
 -   **更新チェック機能**:
     -   ページ読み込み時に GitHub API で `make_jc_importer.html` の最新コミット日を取得し、HTML内の最終更新日（`LOCAL_VERSION`）と比較する

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-06-11（助成情報検索ツールのバグ修正 #149/#150）
+最終更新: 2026-06-15（管理フィールド初期値の定義 #148、ページからのDOI取得をJSON-LD対応に拡張 #159）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -16,6 +16,7 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.11.0 | 2026-06-15 | #148: TSV管理フィールド（`.IndexID[0]` / `.POS_INDEX[0]`）とリポジトリURLの初期値を `shared.js` の `CONFIG`（スタンドアロン版）・`options.html`（Chrome拡張版）で定義可能に。リポジトリURLはChrome拡張ではOpenSearch検索の既定値（`defaultRepositoryUrl`）と共用。`loadConfig()` で `defaultIndexId` / `defaultPosIndex` / `defaultRepositoryUrl` を読込、`renderSystemFields()` / `mapToItemType()` / `mapToItemTypeJaLC()` / `buildEmptyMetadata()` の既定値と `init()` での `repo-host` プリフィルに反映。#159: ページからのDOI取得をJSON-LD対応に拡張（metaタグで取得できない場合、schema.org `ScholarlyArticle` の `identifier` をフォールバック採用、`@graph` 入れ子・`PropertyValue` 形式に対応） |
 | 1.10.1 | 2026-06-11 | #149: 助成情報検索ツールでマルチバイト文字列を含む行から課題番号を抽出できないバグを修正（Case A の判定を「空白なし」→「課題番号として妥当な文字のみ」に変更、区切り文字に全角「、，；」を追加）。#150: 検索結果の外部リンククリックでサイドパネルが既定ページにリセットされる不具合を `chrome.tabs.create` で修正 |
 | 1.10.0 | 2026-06-10 | #73: 電子ジャーナルページのmetaタグからDOIを自動取得するボタンを追加（DOIインポートタブ）。助成情報検索タブにDOI入力欄を新設し、Crossref/OpenAlex経由で課題番号を自動取得する機能を追加 |
 | 1.9.5 | 2026-06-06 | #142: `groupTsvColumns()` 内 `.metadata.path[0]`/`.metadata.pubdate` が `__other__` に分類されTSVスキップされていたバグを修正（`__system__` に変更）、#143: 管理フィールドのIndexID/POS_INDEX候補値ヒントの入れ違いを修正 |

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -490,7 +490,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-06-06 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-06-15 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -502,6 +502,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-15</td>
+        <td style="padding:2px 0;">TSV管理フィールド（.IndexID[0]/.POS_INDEX[0]）とリポジトリURLの初期値を shared.js／設定画面で定義可能に（#148）。電子ジャーナルページからのDOI自動取得をJSON-LD（schema.org）対応に拡張（#159、Chrome拡張版）（Chrome拡張 ver. 1.11.0 と同期）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-06</td>
         <td style="padding:2px 0;">IndexID・公開日がTSVに出力されないバグ修正（#142）、管理フィールドのIndexID/POS_INDEX候補値ヒント誤りを修正（#143）（Chrome拡張 ver. 1.9.5 と同期）</td>
@@ -517,10 +521,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-13</td>
         <td style="padding:2px 0;">Chrome拡張 ver. 1.9.2：Chromeウェブストア登録準備 - 拡張機能アイコン追加 + プライバシーポリシー策定（#112）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-03-29</td>
-        <td style="padding:2px 0;">CONFIG共通化：APIキー設定とChrome拡張ユーティリティをshared.jsに外部化、TSVテンプレートをtsv_headers_template.jsに外部化（#111）</td>
       </tr>
     </tbody>
   </table>
@@ -1336,8 +1336,8 @@ function renderSystemFields(systemData) {
   const sysRows = [
     { label: '.id',                  hint: '新規登録時は空欄', key: 'sys_id',      type: 'text',   default: '' },
     { label: '.uri',                 hint: '新規登録時は空欄', key: 'sys_uri',     type: 'text',   default: '' },
-    { label: '.IndexID[0]',          hint: '1697430475875',     key: 'sys_path',  type: 'text',   default: '' },
-    { label: '.POS_INDEX[0]',        hint: '学術雑誌論文',          key: 'sys_pos', type: 'text',   default: '' },
+    { label: '.IndexID[0]',          hint: '1697430475875',     key: 'sys_path',  type: 'text',   default: CONFIG.DEFAULT_INDEX_ID || '' },
+    { label: '.POS_INDEX[0]',        hint: '学術雑誌論文',          key: 'sys_pos', type: 'text',   default: CONFIG.DEFAULT_POS_INDEX || '' },
     { label: '.PUBLISH_STATUS',      hint: 'private / public', key: 'sys_status',  type: 'select', options: ['private','public'], default: 'private' },
     { label: '.FEEDBACK_MAIL[0]',    hint: '',                  key: 'sys_mail',   type: 'text',   default: '' },
     { label: '.RESEAECHMAP_LINKAGE', hint: '',                  key: 'sys_researchmap', type: 'text', default: '' },
@@ -2658,8 +2658,8 @@ async function mapToItemType(crJson, oaJson, rorMap) {
     system: {
       id:             '',
       uri:            '',
-      path:           '',
-      pos_index:      '',
+      path:           CONFIG.DEFAULT_INDEX_ID || '',
+      pos_index:      CONFIG.DEFAULT_POS_INDEX || '',
       publish_status: 'private',
       feedback_mail:  '',
       researchmap_linkage: '',
@@ -3125,7 +3125,7 @@ async function mapToItemTypeJaLC(jalcJson) {
   // ===== メタデータオブジェクト =====
   const metadata = {
     system: {
-      id: '', uri: '', path: '', pos_index: '',
+      id: '', uri: '', path: CONFIG.DEFAULT_INDEX_ID || '', pos_index: CONFIG.DEFAULT_POS_INDEX || '',
       publish_status: 'private', feedback_mail: '', researchmap_linkage: '',
       cnri: '', doi_ra: '', doi: '',
       edit_mode: 'Keep', pubdate: todayStr(),
@@ -5321,8 +5321,8 @@ function buildMaxSizeMetadata(metadataArray) {
 function buildEmptyMetadata() {
   return {
     system: {
-      id: '', uri: '', path: '',
-      pos_index: '',
+      id: '', uri: '', path: CONFIG.DEFAULT_INDEX_ID || '',
+      pos_index: CONFIG.DEFAULT_POS_INDEX || '',
       publish_status: 'private', feedback_mail: '', researchmap_linkage: '', cnri: '',
       doi_ra: '', doi: '', edit_mode: 'Keep', pubdate: todayStr(),
     },
@@ -6586,6 +6586,12 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
     document.getElementById('cinii-apikey-warning').style.display = 'block';
   }
 
+  // リポジトリURL初期値（未入力時のみ。Chrome拡張は OpenSearch の既定値と共用）
+  const repoHostInput = document.getElementById('repo-host');
+  if (repoHostInput && !repoHostInput.value && CONFIG.DEFAULT_REPOSITORY_URL) {
+    repoHostInput.value = CONFIG.DEFAULT_REPOSITORY_URL;
+  }
+
   // ボタンイベント登録（MV3 CSP対応: inline onclick は使用不可）
   document.getElementById('fetch-btn').addEventListener('click', fetchData);
   document.getElementById('empty-btn').addEventListener('click', showEmptyFields);
@@ -6622,7 +6628,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-06-06';
+  const LOCAL_VERSION = '2026-06-15';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;

--- a/shared.js
+++ b/shared.js
@@ -13,16 +13,37 @@ const CONFIG = {
     // Open Policy Finder APIキー（任意・Chrome拡張版のみ有効）
     // https://openpolicyfinder.jisc.ac.uk/ で取得できます
     OPF_API_KEY: "YOUR_OPF_API_KEY",
+
+    // ===== システム（管理フィールド）・リポジトリURLの初期値（任意） =====
+    // よく使う登録先インデックスやリポジトリURLを設定すると、フォームに初期値として入力されます。
+    // Chrome拡張版では options.html で設定できます（このファイルの編集は不要です）。
+
+    // リポジトリURL（repo-host）。TSVのスキーマURL置換に使用
+    // Chrome拡張版では OpenSearch の「デフォルトリポジトリ URL」と共用します
+    DEFAULT_REPOSITORY_URL: "",
+
+    // .IndexID[0]（.metadata.path[0]）アイテムの登録先インデックスID  例: 1697430475875
+    DEFAULT_INDEX_ID: "",
+
+    // .POS_INDEX[0]（.pos_index[0]）インデックス名パス（人間可読）  例: 学術雑誌論文
+    DEFAULT_POS_INDEX: "",
 };
 
 // ===== Chrome拡張: chrome.storage.local からAPIキーを読み込む =====
 async function loadConfig() {
   if (typeof chrome === 'undefined' || !chrome.storage) return;
   try {
-    const stored = await chrome.storage.local.get(['OpenAlex_API_KEY', 'CiNii_API_KEY', 'OPF_API_KEY']);
+    const stored = await chrome.storage.local.get([
+      'OpenAlex_API_KEY', 'CiNii_API_KEY', 'OPF_API_KEY',
+      'defaultRepositoryUrl', 'defaultIndexId', 'defaultPosIndex',
+    ]);
     if (stored.OpenAlex_API_KEY) CONFIG.OpenAlex_API_KEY = stored.OpenAlex_API_KEY;
     if (stored.CiNii_API_KEY)    CONFIG.CiNii_API_KEY    = stored.CiNii_API_KEY;
     if (stored.OPF_API_KEY)      CONFIG.OPF_API_KEY      = stored.OPF_API_KEY;
+    // システム（管理フィールド）・リポジトリURLの初期値（リポジトリURLは OpenSearch の既定値と共用）
+    if (stored.defaultRepositoryUrl) CONFIG.DEFAULT_REPOSITORY_URL = stored.defaultRepositoryUrl;
+    if (stored.defaultIndexId)       CONFIG.DEFAULT_INDEX_ID       = stored.defaultIndexId;
+    if (stored.defaultPosIndex)      CONFIG.DEFAULT_POS_INDEX      = stored.defaultPosIndex;
   } catch { /* 拡張外環境では無視 */ }
 }
 


### PR DESCRIPTION
## 概要
2件のIssueをまとめて実装しました。

- **#148**: TSV管理（システム）フィールド `.IndexID[0]` / `.POS_INDEX[0]` とリポジトリURLの初期値を、スタンドアロン版は `shared.js` の `CONFIG`、Chrome拡張版は設定画面（`options.html`）で定義可能に。
- **#159**: 「ページからDOI取得」（#73）に JSON-LD（schema.org `ScholarlyArticle`）フォールバックを追加。metaタグでDOIを取得できないページ（Taylor & Francis 等）に対応。

## 変更内容

### #148 管理フィールド・リポジトリURLの初期値設定
- `shared.js`（+ `chrome-extension/shared.js`）: `CONFIG` に `DEFAULT_INDEX_ID` / `DEFAULT_POS_INDEX` / `DEFAULT_REPOSITORY_URL` を追加。`loadConfig()` で `chrome.storage.local` の `defaultIndexId` / `defaultPosIndex` / `defaultRepositoryUrl` を反映（**リポジトリURLは OpenSearch 検索の既定値と共用**）
- `make_jc_importer.html`（+ `make_jc_importer.js`）: `renderSystemFields()` の既定値、`mapToItemType()` / `mapToItemTypeJaLC()` / `buildEmptyMetadata()` の `system.path`/`pos_index`、`init()` の `repo-host` プリフィル（未入力時のみ）に反映
- `options.html` / `options.js`: 「TSV 管理フィールドの初期値」セクション（IndexID / POS_INDEX）を追加。リポジトリURLは既存の「デフォルトリポジトリ URL」を共用

### #159 ページからのDOI取得をJSON-LD対応に拡張
- `make_jc_importer.js` / `funder_lookup.js` の `getDoiFromCurrentTab()` 注入 `func` にフォールバックを追加。metaタグ取得失敗時、`<script type="application/ld+json">` 内の schema.org `ScholarlyArticle` の `identifier` を採用（`@graph` 入れ子の平坦化、文字列 / `PropertyValue` 形式 / 配列対応、DOI形式ガード通過分のみ）。2ファイルは同一実装

### バージョン・ドキュメント
- `manifest.json`: `1.10.1` → `1.11.0`（機能追加 = minor）
- `LOCAL_VERSION`: `2026-06-15`（make_jc_importer.html/js, funder_lookup.js）
- 最終更新日・更新概要テーブル（make_jc_importer.html / panel.html / funder_panel.html）
- README（最新の更新 + 変更履歴 + 設定セクションを統合）、docs/requirements.md、docs/worklog.md

## テスト
- **E2E（Playwright, ALL PASSED）**: main（メタデータ取得）/ funder連携（JP19KK0341）/ #148プリフィル検証（フォーム初期値→DOM収集→TSV出力列まで一貫反映）/ #159 JSON-LD抽出（実コードの `func` を実DOMで実行、Issue例の抽出・metaタグ優先・該当なし→null の回帰確認）
- **手動確認**: #148 = test HTMLで既定値設定→空テーブル表示で反映を確認。#159 = tandfonline の対象記事で `10.1080/1343943X.2026.2682196` が取得できることを確認

Closes #148
Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)