### PR TITLE
fix: 助成情報「プログラム情報識別子タイプ」の空欄時の既定値誤出力を修正 (#161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張機能版 | 2026-06-15 | ver. 1.11.0 | TSV管理フィールド（`.IndexID[0]` / `.POS_INDEX[0]`）とリポジトリURLの初期値を設定画面で定義可能に（[#148](https://github.com/tzhaya/jc-import-file-maker/issues/148)）。ページからのDOI自動取得をJSON-LD（schema.org `ScholarlyArticle`）対応に拡張（[#159](https://github.com/tzhaya/jc-import-file-maker/issues/159)） |
-| インポート用TSV生成ツール | 2026-06-15 | — | TSV管理フィールド（`.IndexID[0]` / `.POS_INDEX[0]`）とリポジトリURLの初期値を `shared.js` で定義可能に（[#148](https://github.com/tzhaya/jc-import-file-maker/issues/148)） |
+| Chrome拡張機能版 | 2026-06-19 | ver. 1.11.1 | 助成情報「プログラム情報識別子タイプ」が、識別子本体が空欄のときに既定値（`Crossref Funder`）を誤ってTSV出力する不具合を修正（[#161](https://github.com/tzhaya/jc-import-file-maker/issues/161)） |
+| インポート用TSV生成ツール | 2026-06-19 | — | 助成情報「プログラム情報識別子タイプ」が、識別子本体が空欄のときに既定値（`Crossref Funder`）を誤ってTSV出力する不具合を修正（[#161](https://github.com/tzhaya/jc-import-file-maker/issues/161)） |
 | 助成情報検索ツール | 2026-06-11 | — | マルチバイト文字列（日本語）を含む行から課題番号を抽出できないバグを修正（[#149](https://github.com/tzhaya/jc-import-file-maker/issues/149)）。検索結果の外部リンクをクリックするとツールがリロードされる不具合を修正（[#150](https://github.com/tzhaya/jc-import-file-maker/issues/150)） |
 
 ## 導入方法
@@ -315,6 +315,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-06-19 | 助成情報の「プログラム情報識別子タイプ」（`subitem_funding_stream_identifier_type`）の選択肢先頭に空の項目を追加し、識別子本体が空欄のときに既定値 `Crossref Funder` が自動選択されてTSVに誤出力される不具合を修正（[#161](https://github.com/tzhaya/jc-import-file-maker/issues/161)）。manifest version `1.11.0` → `1.11.1` |
 | 2026-06-15 | TSV管理フィールドの初期値を設定可能に：`.IndexID[0]`（登録先インデックスID）・`.POS_INDEX[0]`（インデックス名パス）とリポジトリURLの初期値を、スタンドアロン版は `shared.js` の `CONFIG`、Chrome拡張版は設定画面（`options.html`）で定義できるよう対応。リポジトリURLはChrome拡張ではOpenSearch検索の既定値と共用（[#148](https://github.com/tzhaya/jc-import-file-maker/issues/148)） |
 | 2026-06-15 | 電子ジャーナルページからのDOI自動取得（[#73](https://github.com/tzhaya/jc-import-file-maker/issues/73)）をJSON-LD対応に拡張：metaタグでDOIを取得できない場合、`<script type="application/ld+json">` 内の schema.org `ScholarlyArticle` の `identifier`（文字列／`PropertyValue` 形式、`@graph` 入れ子に対応）をフォールバックとして採用（[#159](https://github.com/tzhaya/jc-import-file-maker/issues/159)）。manifest version `1.10.1` → `1.11.0` |
 | 2026-06-10 | ドキュメント整合性修正：README・使い方ガイドを現在の実装に同期（#73新機能の反映、`shared.js`/`tsv_headers_template.js` 依存の明記、TSV出力ファイル名の記述修正、機能比較表・ディレクトリ構成の更新） |

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -563,7 +563,8 @@ const TITLE_MAPS = {
   // 助成機関識別子タイプ
   subitem_funder_identifier_type: ['Crossref Funder','e-Rad_funder','ISNI','ROR','Other'],
   // プログラム情報識別子タイプ（JPCOAR 2.0）
-  subitem_funding_stream_identifier_type: ['Crossref Funder','JGN_fundingStream'],
+  // 先頭に空選択肢を置き、識別子本体が空のとき既定値が誤出力されるのを防ぐ（#161）
+  subitem_funding_stream_identifier_type: [{ name: '（未設定）', value: '' }, 'Crossref Funder', 'JGN_fundingStream'],
   // ファイル情報: アクセス
   file_accessrole: ['open_access','open_date','open_login','open_no'],
   // ファイル情報: 表示形式
@@ -6095,7 +6096,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-06-15';
+  const LOCAL_VERSION = '2026-06-19';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "JAIRO Cloud（WEKO3）に登録するメタデータの作成とインポートを支援するChrome拡張機能です。DOIを入力するだけで、Crossref / JaLC / OpenAlex から書誌メタデータを自動で取得します。",
   "icons": {
     "16": "icons/icon16.png",

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -500,7 +500,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-06-15 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-06-19 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -512,6 +512,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-19</td>
+        <td style="padding:2px 0;">Chrome拡張 ver. 1.11.1：助成情報「プログラム情報識別子タイプ」が、識別子本体が空欄のときに既定値（Crossref Funder）を誤ってTSV出力する不具合を修正（#161）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-15</td>
         <td style="padding:2px 0;">Chrome拡張 ver. 1.11.0：TSV管理フィールド（.IndexID[0]/.POS_INDEX[0]）とリポジトリURLの初期値を設定画面で定義可能に（#148）。ページからのDOI自動取得をJSON-LD（schema.org ScholarlyArticle）対応に拡張（#159）</td>
@@ -527,10 +531,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-15</td>
         <td style="padding:2px 0;">Chrome拡張 ver. 1.9.4：最終更新日・更新概要テーブルの表示情報を整理し、5月の実作業を反映</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-14</td>
-        <td style="padding:2px 0;">Chrome拡張 ver. 1.9.3：ストア公開名と一致するようツール名を「JAIRO Cloud インポート支援ツール」に統一（#138, #139）</td>
       </tr>
     </tbody>
   </table>

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -560,7 +560,7 @@ ItemType.json には複数レベルのネスト構造を持つフィールドが
 **プログラム情報（JPCOAR 2.0 fundingStream / fundingStreamIdentifier）**（[issue #34](https://github.com/tzhaya/jc-import-file-maker/issues/34)）:
 - `subitem_funding_stream_identifiers`: プログラム情報識別子（単一オブジェクト）
   - `subitem_funding_stream_identifier`: 識別子値
-  - `subitem_funding_stream_identifier_type`: 識別子タイプ（`Crossref Funder` / `JGN_fundingStream`）
+  - `subitem_funding_stream_identifier_type`: 識別子タイプ（`Crossref Funder` / `JGN_fundingStream`）。選択肢の先頭は空項目（未設定）とし、識別子値が空のときは識別子タイプも空のままTSV出力する（既定値 `Crossref Funder` の誤出力を防止、[issue #161](https://github.com/tzhaya/jc-import-file-maker/issues/161)）
   - `subitem_funding_stream_identifier_type_uri`: 識別子タイプURI
 - `subitem_funding_streams[]`: プログラム情報（配列、複数言語対応）
   - `subitem_funding_stream`: プログラム情報テキスト

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,6 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-06-15（管理フィールド初期値の定義 #148、ページからのDOI取得をJSON-LD対応に拡張 #159）
+最終更新: 2026-06-19（助成情報「プログラム情報識別子タイプ」の空欄時 既定値誤出力を修正 #161）
 
 ## プロジェクト概要
 JAIRO Cloud インポート用TSV生成ツール (`make_jc_importer.html`) の新規実装。
@@ -16,6 +16,7 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.11.1 | 2026-06-19 | #161: 助成情報「プログラム情報識別子タイプ」（`subitem_funding_stream_identifier_type`）の選択肢先頭に空項目 `{ name: '（未設定）', value: '' }` を追加。識別子本体が空欄のとき `<select>` が先頭の `Crossref Funder` を自動選択し、`collectFundingField()` の DOM 再回収を経てTSVへ既定値が誤出力される不具合を修正 |
 | 1.11.0 | 2026-06-15 | #148: TSV管理フィールド（`.IndexID[0]` / `.POS_INDEX[0]`）とリポジトリURLの初期値を `shared.js` の `CONFIG`（スタンドアロン版）・`options.html`（Chrome拡張版）で定義可能に。リポジトリURLはChrome拡張ではOpenSearch検索の既定値（`defaultRepositoryUrl`）と共用。`loadConfig()` で `defaultIndexId` / `defaultPosIndex` / `defaultRepositoryUrl` を読込、`renderSystemFields()` / `mapToItemType()` / `mapToItemTypeJaLC()` / `buildEmptyMetadata()` の既定値と `init()` での `repo-host` プリフィルに反映。#159: ページからのDOI取得をJSON-LD対応に拡張（metaタグで取得できない場合、schema.org `ScholarlyArticle` の `identifier` をフォールバック採用、`@graph` 入れ子・`PropertyValue` 形式に対応） |
 | 1.10.1 | 2026-06-11 | #149: 助成情報検索ツールでマルチバイト文字列を含む行から課題番号を抽出できないバグを修正（Case A の判定を「空白なし」→「課題番号として妥当な文字のみ」に変更、区切り文字に全角「、，；」を追加）。#150: 検索結果の外部リンククリックでサイドパネルが既定ページにリセットされる不具合を `chrome.tabs.create` で修正 |
 | 1.10.0 | 2026-06-10 | #73: 電子ジャーナルページのmetaタグからDOIを自動取得するボタンを追加（DOIインポートタブ）。助成情報検索タブにDOI入力欄を新設し、Crossref/OpenAlex経由で課題番号を自動取得する機能を追加 |

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -490,7 +490,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-06-15 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-06-19 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -502,6 +502,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-19</td>
+        <td style="padding:2px 0;">助成情報「プログラム情報識別子タイプ」が、識別子本体が空欄のときに既定値（Crossref Funder）を誤ってTSV出力する不具合を修正（#161）（Chrome拡張 ver. 1.11.1 と同期）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-15</td>
         <td style="padding:2px 0;">TSV管理フィールド（.IndexID[0]/.POS_INDEX[0]）とリポジトリURLの初期値を shared.js／設定画面で定義可能に（#148）。電子ジャーナルページからのDOI自動取得をJSON-LD（schema.org）対応に拡張（#159、Chrome拡張版）（Chrome拡張 ver. 1.11.0 と同期）</td>
@@ -517,10 +521,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-14</td>
         <td style="padding:2px 0;">Chrome拡張 ver. 1.9.3：ストア公開名と一致するようツール名を「JAIRO Cloud インポート支援ツール」に統一（#138, #139）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-13</td>
-        <td style="padding:2px 0;">Chrome拡張 ver. 1.9.2：Chromeウェブストア登録準備 - 拡張機能アイコン追加 + プライバシーポリシー策定（#112）</td>
       </tr>
     </tbody>
   </table>
@@ -1215,7 +1215,8 @@ const TITLE_MAPS = {
   // 助成機関識別子タイプ
   subitem_funder_identifier_type: ['Crossref Funder','e-Rad_funder','ISNI','ROR','Other'],
   // プログラム情報識別子タイプ（JPCOAR 2.0）
-  subitem_funding_stream_identifier_type: ['Crossref Funder','JGN_fundingStream'],
+  // 先頭に空選択肢を置き、識別子本体が空のとき既定値が誤出力されるのを防ぐ（#161）
+  subitem_funding_stream_identifier_type: [{ name: '（未設定）', value: '' }, 'Crossref Funder', 'JGN_fundingStream'],
   // ファイル情報: アクセス
   file_accessrole: ['open_access','open_date','open_login','open_no'],
   // ファイル情報: 表示形式
@@ -6628,7 +6629,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-06-15';
+  const LOCAL_VERSION = '2026-06-19';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;


### PR DESCRIPTION
## 概要
助成情報の「プログラム情報識別子タイプ」（`subitem_funding_stream_identifier_type`）が、識別子本体（`subitem_funding_stream_identifier`）が空欄のときでも既定値 `Crossref Funder` として TSV に出力される不具合を修正します。

Closes #161

## 原因
「識別子タイプ」は `<select>`（選択肢 `['Crossref Funder','JGN_fundingStream']`）で描画され、空文字に一致する option が無いため、値が空のときブラウザが先頭 option `Crossref Funder` を自動選択していました。これを `collectFundingField()` が `getFieldVal()` で拾い、識別子本体が空でも既定値が TSV へ混入していました。データ構築側（`mapToItemType()` 等）は `type=''` を正しく設定済みで、**DOM 再描画 → 再回収のラウンドトリップに限局**した不具合です。

## 修正
`TITLE_MAPS.subitem_funding_stream_identifier_type` の選択肢先頭に空項目 `{ name: '（未設定）', value: '' }` を追加しました。

- 値が空のとき空 option が選択され、`getFieldVal()` が `''` を返す → TSV も空。
- 先頭に置くことで「先頭 option を既定選択」フォールバックでも空になり二重に安全。
- `JGN_fundingStream` 等が入るケースは従来通り維持（リグレッションなし）。

## 変更ファイル
- `make_jc_importer.html` / `chrome-extension/make_jc_importer.js`（+ テスト用 `make_jc_importer_test.html`）: 空 option 追加、`LOCAL_VERSION` → `2026-06-19`、最終更新日・更新概要テーブル
- `chrome-extension/panel.html`: 更新概要テーブル
- `chrome-extension/manifest.json`: version `1.11.0` → `1.11.1`（patch）
- `README.md` / `docs/requirements.md` / `docs/worklog.md`: 更新

## E2E テスト（`/e2e-test`）— ALL PASSED
- `collectFromDOM()` の出力で issue と同じフィールド `item_30002_funding_reference21[0]/[1]` がいずれも `id='' type=''`（修正前は `type='Crossref Funder'`）になることを確認。
- 識別子タイプ select の先頭が空 option であることを確認。
- 標準チェック（タイトル / 著者 / DOIリンク / 資源タイプ / セクション数）合格。
- 連携 funder テスト（課題番号 `JP19KK0341`）も合格。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
