### PR TITLE
feat: OpenAlex由来RORの誤同定検出と注意喚起 (#165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張機能版 | 2026-06-19 | ver. 1.11.1 | 助成情報「プログラム情報識別子タイプ」が、識別子本体が空欄のときに既定値（`Crossref Funder`）を誤ってTSV出力する不具合を修正（[#161](https://github.com/tzhaya/jc-import-file-maker/issues/161)） |
-| インポート用TSV生成ツール | 2026-06-19 | — | 助成情報「プログラム情報識別子タイプ」が、識別子本体が空欄のときに既定値（`Crossref Funder`）を誤ってTSV出力する不具合を修正（[#161](https://github.com/tzhaya/jc-import-file-maker/issues/161)） |
+| Chrome拡張機能版 | 2026-06-22 | ver. 1.12.0 | OpenAlex由来で著者所属に付与したRORに「要確認」表示を追加。OpenAlexの機関同定がCrossrefの所属表記と一致しない誤同定の疑いを検出し、RORを設定せず注意喚起（[#165](https://github.com/tzhaya/jc-import-file-maker/issues/165)） |
+| インポート用TSV生成ツール | 2026-06-22 | — | OpenAlex由来で著者所属に付与したRORに「要確認」表示を追加。OpenAlexの機関同定がCrossrefの所属表記と一致しない誤同定の疑いを検出し、RORを設定せず注意喚起（[#165](https://github.com/tzhaya/jc-import-file-maker/issues/165)） |
 | 助成情報検索ツール | 2026-06-11 | — | マルチバイト文字列（日本語）を含む行から課題番号を抽出できないバグを修正（[#149](https://github.com/tzhaya/jc-import-file-maker/issues/149)）。検索結果の外部リンクをクリックするとツールがリロードされる不具合を修正（[#150](https://github.com/tzhaya/jc-import-file-maker/issues/150)） |
 
 ## 導入方法
@@ -316,6 +316,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-06-22 | Crossref が著者所属に ROR を持たない場合に OpenAlex が機械同定した ROR を付与しているが、誤同定があるため対応（[#165](https://github.com/tzhaya/jc-import-file-maker/issues/165)）。(1) OpenAlex 由来の ROR の URI 欄に「⚠ 要確認」バッジを常時表示。(2) OpenAlex が同定した機関名と、同定元の Crossref 所属表記（`raw_affiliation_string`）を有意トークンで照合し（機関名トークンの過半数一致を主、最上位組織名照合を補助とする2段階判定）、誤同定の疑いがある場合は ROR を設定せず Crossref 所属表記を機関名として採用、機関名欄に注意喚起（部局名など下位階層は機関名まで編集する旨も表示）。manifest version `1.11.1` → `1.12.0` |
 | 2026-06-19 | GitHub Pages の紹介ページ（`docs/index.html`）を新規作成。空だった https://tzhaya.github.io/jc-import-file-maker/ に、概要・2つの利用方法・機能比較・3つのツール・導入方法・「作者から」を掲載（README をベースにした自己完結HTML） |
 | 2026-06-19 | 助成情報の「プログラム情報識別子タイプ」（`subitem_funding_stream_identifier_type`）の選択肢先頭に空の項目を追加し、識別子本体が空欄のときに既定値 `Crossref Funder` が自動選択されてTSVに誤出力される不具合を修正（[#161](https://github.com/tzhaya/jc-import-file-maker/issues/161)）。manifest version `1.11.0` → `1.11.1` |
 | 2026-06-15 | TSV管理フィールドの初期値を設定可能に：`.IndexID[0]`（登録先インデックスID）・`.POS_INDEX[0]`（インデックス名パス）とリポジトリURLの初期値を、スタンドアロン版は `shared.js` の `CONFIG`、Chrome拡張版は設定画面（`options.html`）で定義できるよう対応。リポジトリURLはChrome拡張ではOpenSearch検索の既定値と共用（[#148](https://github.com/tzhaya/jc-import-file-maker/issues/148)） |

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -1598,6 +1598,54 @@ function getPubDate(cr) {
   return formatDateParts(parts);
 }
 
+// ===== 4.3 著者所属の誤同定判定（OpenAlex ROR） =====
+// 機関名照合で無視する汎用語（組織種別・接続詞・分野語など）
+const AFF_GENERIC_WORDS = new Set([
+  'of','the','and','for','de','des','du','la','le','el','et',
+  'university','universities','univ','college','faculty','department','dept',
+  'school','institute','institut','institution','center','centre','graduate',
+  'division','laboratory','lab','research','science','sciences','studies',
+  'national','state','co','corp','corporation','inc','ltd',
+]);
+// 末尾セグメント判定で除外する国・地域名
+const AFF_GEO_WORDS = new Set([
+  'japan','usa','us','uk','china','korea','france','germany','italy','spain',
+  'india','philippines','canada','australia','brazil','russia','taiwan',
+  'thailand','indonesia','malaysia','vietnam','singapore','netherlands',
+]);
+function affNameTokens(s) {
+  return (s || '').toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .split(/\s+/)
+    .filter(t => t.length >= 3 && !AFF_GENERIC_WORDS.has(t));
+}
+// Crossref 所属表記の最上位組織名（末尾カンマセグメント。末尾の国・地域名は除外）を返す
+function topLevelOrgSegment(rawAff) {
+  const segs = (rawAff || '').split(',').map(s => s.trim()).filter(Boolean);
+  while (segs.length > 1) {
+    const toks = segs[segs.length - 1].toLowerCase().split(/\s+/).filter(Boolean);
+    if (toks.length && toks.every(t => AFF_GEO_WORDS.has(t))) segs.pop();
+    else break;
+  }
+  return segs[segs.length - 1] || (rawAff || '');
+}
+// OpenAlex が同定した機関名と Crossref 所属表記を照合し、誤同定の疑いを判定する。
+// (1) 機関名の有意トークンの過半数が所属表記に出現すれば整合とみなす（住所・メール等の
+//     雑多な文字列を含む実データでも、機関名が綴られていれば誤検出しない）。
+// (2) 過半数に満たない場合のみ、最上位組織名（末尾カンマセグメント）とのトークン共有を確認。
+//     どちらとも共有しなければ誤同定の疑いありとする。判定材料が無い場合は false（設定維持）。
+function isAffMisidentified(instName, rawAff) {
+  if (!rawAff) return false;
+  const instTokens = affNameTokens(instName);
+  if (!instTokens.length) return false;
+  const rawSet = new Set(affNameTokens(rawAff));
+  const matched = instTokens.filter(t => rawSet.has(t)).length;
+  if (matched * 2 > instTokens.length) return false;
+  const orgTokens = affNameTokens(topLevelOrgSegment(rawAff));
+  if (!orgTokens.length) return false;
+  return !orgTokens.some(t => instTokens.includes(t));
+}
+
 // ===== 4.3 著者マッピング =====
 function buildAuthors(crAuthors, oaAuthorships, rorMap) {
   // OpenAlex 著者を姓で索引化
@@ -1629,6 +1677,14 @@ function buildAuthors(crAuthors, oaAuthorships, rorMap) {
     const orcidId = orcidUri.replace(/^https?:\/\/orcid\.org\//i, '');
 
     // 所属: OpenAlex authorships[].institutions を使用
+    // OpenAlex 機関 id → 同定元の Crossref 所属表記 を対応付け（誤同定判定用）
+    const instIdToRaw = {};
+    (oaEntry?.affiliations || []).forEach(af => {
+      (af.institution_ids || []).forEach(id => {
+        if (id && !instIdToRaw[id]) instIdToRaw[id] = af.raw_affiliation_string || '';
+      });
+    });
+
     const oaInsts = oaEntry?.institutions || [];
     const affiliations = oaInsts.map(inst => {
       const rorUri = inst.ror || '';
@@ -1636,6 +1692,16 @@ function buildAuthors(crAuthors, oaAuthorships, rorMap) {
       const dispName = rorInfo.rorDisplayName || inst.display_name || '';
       const isni     = rorInfo.isni || '';
       const rorId    = rorInfo.rorId || '';
+
+      // 同定元の Crossref 所属表記と機関名を突合し、誤同定を判定
+      const rawAff = instIdToRaw[inst.id] || '';
+      if (rawAff && isAffMisidentified(inst.display_name || dispName, rawAff)) {
+        // 誤同定の疑い: ROR/ISNI を設定せず、Crossref の所属表記を機関名に採用（要編集）
+        return {
+          affiliationNames: [{ affiliationName: rawAff, affiliationNameLang: 'en', _warnLang: true, _warnAffNameRaw: true }],
+          affiliationNameIdentifiers: [],
+        };
+      }
 
       const affiliationNameIdentifiers = [];
       if (isni) affiliationNameIdentifiers.push({
@@ -1647,6 +1713,7 @@ function buildAuthors(crAuthors, oaAuthorships, rorMap) {
         affiliationNameIdentifier:       rorId,
         affiliationNameIdentifierScheme: 'ROR',
         affiliationNameIdentifierURI:    `https://ror.org/${rorId}`,
+        _warnRor: true,
       });
 
       return {
@@ -3399,7 +3466,10 @@ function renderOneAffiliation(aff, ai, keys, sfx) {
   }, sfx ? JPCOAR_SUBFIELD_LINKS[sfx + '_aff_name'] : undefined);
   (aff[affNameKey] || []).forEach(an => {
     const { grp, delBtn } = createEntryGroup();
-    grp.appendChild(createFieldRow('所属機関名', an[affNameField] || '', 'text', null, { fieldKey: affNameField }));
+    grp.appendChild(createFieldRow('所属機関名', an[affNameField] || '', 'text', null, {
+      fieldKey: affNameField, warn: an._warnAffNameRaw,
+      warnTitle: 'OpenAlex が同定した機関が Crossref の所属表記と一致しないため ROR を設定していません。記入は機関名までです。部局名など下位階層がある場合は編集してください。'
+    }));
     grp.appendChild(createFieldRow('言語', an[affNameLangField] || '', 'select', 'language', {
       fieldKey: affNameLangField, warn: an._warnLang, warnTitle: '仮に英語として設定しています。正確か確認してください'
     }));
@@ -3469,7 +3539,10 @@ function renderOneAffiliation(aff, ai, keys, sfx) {
         fieldKey: affIdSchemeField,
         onChange: () => updateAffLookup(),
       }));
-    aidContent.appendChild(createFieldRow('URI', aid[affIdUriField] || '', 'text', null, { fieldKey: affIdUriField }));
+    aidContent.appendChild(createFieldRow('URI', aid[affIdUriField] || '', 'text', null, {
+      fieldKey: affIdUriField, warn: aid._warnRor,
+      warnTitle: 'OpenAlex が機械同定した ROR です。正確か確認してください'
+    }));
 
     // (3) Scheme select が DOM にある状態で attachLookupUi を呼ぶ
     const { updateVisibility } = attachLookupUi({
@@ -6096,7 +6169,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-06-19';
+  const LOCAL_VERSION = '2026-06-22';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "JAIRO Cloud（WEKO3）に登録するメタデータの作成とインポートを支援するChrome拡張機能です。DOIを入力するだけで、Crossref / JaLC / OpenAlex から書誌メタデータを自動で取得します。",
   "icons": {
     "16": "icons/icon16.png",

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -500,7 +500,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-06-19 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-06-22 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -512,6 +512,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-22</td>
+        <td style="padding:2px 0;">Chrome拡張 ver. 1.12.0：OpenAlex由来で著者所属に付与したRORに「要確認」表示を追加。OpenAlexの機関同定がCrossrefの所属表記と一致しない誤同定の疑いを検出し、RORを設定せず注意喚起する対応（#165）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-19</td>
         <td style="padding:2px 0;">Chrome拡張 ver. 1.11.1：助成情報「プログラム情報識別子タイプ」が、識別子本体が空欄のときに既定値（Crossref Funder）を誤ってTSV出力する不具合を修正（#161）</td>
@@ -527,10 +531,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-06</td>
         <td style="padding:2px 0;">Chrome拡張 ver. 1.9.5：IndexID・公開日がTSVに出力されないバグ修正（#142）、管理フィールドのIndexID/POS_INDEX候補値ヒント誤りを修正（#143）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-15</td>
-        <td style="padding:2px 0;">Chrome拡張 ver. 1.9.4：最終更新日・更新概要テーブルの表示情報を整理し、5月の実作業を反映</td>
       </tr>
     </tbody>
   </table>

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -118,6 +118,11 @@ make_jc_importer.html
 -   **ROR/ISNI情報との連携**
     -   OpenAlexから取得したROR IDを基に、ROR v2 APIを介してISNI情報を取得し、所属機関の識別子として活用します。
     -   所属機関名として、ROR v2 APIから得られる情報のうち "types" が ["ror_display"] に該当する要素のlabelを使用します。 
+    -   **OpenAlex由来RORの注意喚起と誤同定検出**（[issue #165](https://github.com/tzhaya/jc-import-file-maker/issues/165)）:
+        -   OpenAlexが機械同定したROR（`authorships[].institutions[].ror`）由来の所属機関識別子URIには、ORCID同様に`⚠ 要確認`を表示します。titleは`OpenAlex が機械同定した ROR です。正確か確認してください`とします。
+        -   OpenAlexが同定した機関名（`institutions[].display_name`）と、同定元のCrossref所属表記（`affiliations[].institution_ids` で対応付く `raw_affiliation_string`）を、汎用語（university/college/institute 等）と3文字未満を除いた有意トークンで照合します。判定は2段階です。(1) 機関名トークンの過半数が所属表記に出現すれば整合とみなします（住所・メールアドレス等を含む実データでも、機関名が綴られていれば誤検出しません）。(2) 過半数に満たない場合のみ、所属表記の最上位組織名（末尾カンマセグメント。末尾の国・地域名は除外）とトークンを共有するか確認し、共有しない場合に誤同定の疑いありと判定します。
+        -   誤同定の疑いがある場合は ROR/ISNI を所属機関識別子として設定せず、所属機関名にはCrossref所属表記をそのまま採用したうえで、所属機関名欄に`⚠ 要確認`を表示します。titleは`OpenAlex が同定した機関が Crossref の所属表記と一致しないため ROR を設定していません。記入は機関名までです。部局名など下位階層がある場合は編集してください。`とし、JPCOARスキーマガイドライン（記入は機関名までとし、部局名など下位階層の所属は記入しない）への対応も促します。
+        -   判定材料（対応付くCrossref所属表記）が無い場合は誤同定と判定せず、ROR を維持したうえで上記の`⚠ 要確認`表示のみ行います。
 -   **ORCIDの取得**
     -   ORCIDは次の優先順位で取得します。
         + Crossref APIから取得

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,31 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-06-19（GitHub Pages 紹介ページ `docs/index.html` を新規作成）
+最終更新: 2026-06-22（#165: OpenAlex由来RORの誤同定検出・注意喚起）
+
+## OpenAlex由来RORの誤同定への対応（2026-06-22, #165）
+
+### 概要
+Crossref が著者所属に ROR を持たない場合、本ツールは OpenAlex `authorships[].institutions[]` から所属名・ROR を付与しているが、OpenAlex の機関同定が誤っているケースがある（例: https://doi.org/10.3759/tropics.simm06 の 1st author で生所属 `College of Fisheries and Marine Sciences, Aklan State University` が `NOAA National Marine Fisheries Service` に誤同定）。ORCID 同様の注意喚起表示に加え、誤同定の疑いを検出して ROR を設定しない対応を実装。
+
+### 実装内容
+- `buildAuthors()` 直前に判定ヘルパーを追加:
+  - `affNameTokens()` — 機関名を正規化（小文字化・記号除去）し、汎用語（`AFF_GENERIC_WORDS`: university/college/institute 等）と3文字未満を除いた有意トークン配列を返す
+  - `topLevelOrgSegment()` — Crossref 所属表記の末尾カンマセグメント（最上位組織名）を返す。末尾の国・地域名（`AFF_GEO_WORDS`）は除外
+  - `isAffMisidentified()` — 2段階判定。(1) 機関名トークンの過半数が `raw_affiliation_string` に出現すれば整合（住所・メール等を含む実データの誤検出を防ぐ）。(2) 過半数未満のときのみ最上位組織名とのトークン共有を確認し、共有しなければ誤同定。判定材料が無い場合は false（設定維持）。※当初は最上位組織名のみで判定したが、E2E で `advnut.2025.100480`（JIRCAS、住所・メール付き raw）が誤検出されたため過半数判定を前段に追加
+- `buildAuthors()` 所属マッピング:
+  - `oaEntry.affiliations[]` の `institution_ids` で OpenAlex 機関 id → 同定元 `raw_affiliation_string` を対応付け
+  - 誤同定の疑い時は ROR/ISNI を付与せず、`affiliationName` に Crossref 所属表記を採用し `_warnAffNameRaw` フラグを付与
+  - 正常同定時は従来どおり `display_name` + ROR を付与し、ROR 識別子に `_warnRor` フラグを付与
+- `renderOneAffiliation()`:
+  - 所属機関名欄に `_warnAffNameRaw` の warn バッジ（ROR 未設定理由＋「機関名まで編集」喚起、JPCOAR スキーマ準拠）
+  - ROR URI 欄に `_warnRor` の warn バッジ（「OpenAlex が機械同定した ROR です。正確か確認してください」）
+
+### 変更ファイル
+- `make_jc_importer.html` — 判定ヘルパー追加、`buildAuthors()`、`renderOneAffiliation()`、最終更新日・更新概要テーブル、`LOCAL_VERSION` `2026-06-19` → `2026-06-22`
+- `chrome-extension/make_jc_importer.js` — 同期（ボタン追加なしのため `init()` 変更なし）、`LOCAL_VERSION` 同期
+- `make_jc_importer_test.html` — 同期（E2E用）
+- `chrome-extension/panel.html` — 最終更新日・更新概要テーブル
+- `chrome-extension/manifest.json` — version `1.11.1` → `1.12.0`（feature/minor）
 
 ## GitHub Pages 紹介ページの作成（2026-06-19）
 
@@ -27,6 +52,7 @@ DOI を入力して Crossref / OpenAlex / ROR API から書誌メタデータを
 
 | バージョン | 日付 | 内容 |
 |---|---|---|
+| 1.12.0 | 2026-06-22 | #165: OpenAlex由来で著者所属に付与したRORの誤同定対応。ROR識別子に `_warnRor`、所属機関名に `_warnAffNameRaw` フラグを追加し warn バッジ表示。`isAffMisidentified()`（機関名トークンの過半数一致→不足時に最上位組織名照合の2段階）で誤同定の疑いを検出した場合、ROR/ISNIを設定せず Crossref所属表記を機関名に採用。E2E ALL PASSED（`tropics.simm06` でAklan→NOAA誤同定を検出、`advnut.2025.100480` のJIRCAS誤検出が無いことを確認） |
 | 1.11.1 | 2026-06-19 | #161: 助成情報「プログラム情報識別子タイプ」（`subitem_funding_stream_identifier_type`）の選択肢先頭に空項目 `{ name: '（未設定）', value: '' }` を追加。識別子本体が空欄のとき `<select>` が先頭の `Crossref Funder` を自動選択し、`collectFundingField()` の DOM 再回収を経てTSVへ既定値が誤出力される不具合を修正 |
 | 1.11.0 | 2026-06-15 | #148: TSV管理フィールド（`.IndexID[0]` / `.POS_INDEX[0]`）とリポジトリURLの初期値を `shared.js` の `CONFIG`（スタンドアロン版）・`options.html`（Chrome拡張版）で定義可能に。リポジトリURLはChrome拡張ではOpenSearch検索の既定値（`defaultRepositoryUrl`）と共用。`loadConfig()` で `defaultIndexId` / `defaultPosIndex` / `defaultRepositoryUrl` を読込、`renderSystemFields()` / `mapToItemType()` / `mapToItemTypeJaLC()` / `buildEmptyMetadata()` の既定値と `init()` での `repo-host` プリフィルに反映。#159: ページからのDOI取得をJSON-LD対応に拡張（metaタグで取得できない場合、schema.org `ScholarlyArticle` の `identifier` をフォールバック採用、`@graph` 入れ子・`PropertyValue` 形式に対応） |
 | 1.10.1 | 2026-06-11 | #149: 助成情報検索ツールでマルチバイト文字列を含む行から課題番号を抽出できないバグを修正（Case A の判定を「空白なし」→「課題番号として妥当な文字のみ」に変更、区切り文字に全角「、，；」を追加）。#150: 検索結果の外部リンククリックでサイドパネルが既定ページにリセットされる不具合を `chrome.tabs.create` で修正 |

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -490,7 +490,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-06-19 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-06-22 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -502,6 +502,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-22</td>
+        <td style="padding:2px 0;">OpenAlex由来で著者所属に付与したRORに「要確認」表示を追加。OpenAlexの機関同定がCrossrefの所属表記と一致しない誤同定の疑いを検出し、RORを設定せず注意喚起する対応（#165）（Chrome拡張 ver. 1.12.0 と同期）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-19</td>
         <td style="padding:2px 0;">助成情報「プログラム情報識別子タイプ」が、識別子本体が空欄のときに既定値（Crossref Funder）を誤ってTSV出力する不具合を修正（#161）（Chrome拡張 ver. 1.11.1 と同期）</td>
@@ -517,10 +521,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-15</td>
         <td style="padding:2px 0;">最終更新日・更新概要テーブルの表示情報を整理し、5月の実作業を反映（Chrome拡張 ver. 1.9.4 と同期）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-05-14</td>
-        <td style="padding:2px 0;">Chrome拡張 ver. 1.9.3：ストア公開名と一致するようツール名を「JAIRO Cloud インポート支援ツール」に統一（#138, #139）</td>
       </tr>
     </tbody>
   </table>
@@ -2145,6 +2145,54 @@ function getPubDate(cr) {
   return formatDateParts(parts);
 }
 
+// ===== 4.3 著者所属の誤同定判定（OpenAlex ROR） =====
+// 機関名照合で無視する汎用語（組織種別・接続詞・分野語など）
+const AFF_GENERIC_WORDS = new Set([
+  'of','the','and','for','de','des','du','la','le','el','et',
+  'university','universities','univ','college','faculty','department','dept',
+  'school','institute','institut','institution','center','centre','graduate',
+  'division','laboratory','lab','research','science','sciences','studies',
+  'national','state','co','corp','corporation','inc','ltd',
+]);
+// 末尾セグメント判定で除外する国・地域名
+const AFF_GEO_WORDS = new Set([
+  'japan','usa','us','uk','china','korea','france','germany','italy','spain',
+  'india','philippines','canada','australia','brazil','russia','taiwan',
+  'thailand','indonesia','malaysia','vietnam','singapore','netherlands',
+]);
+function affNameTokens(s) {
+  return (s || '').toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .split(/\s+/)
+    .filter(t => t.length >= 3 && !AFF_GENERIC_WORDS.has(t));
+}
+// Crossref 所属表記の最上位組織名（末尾カンマセグメント。末尾の国・地域名は除外）を返す
+function topLevelOrgSegment(rawAff) {
+  const segs = (rawAff || '').split(',').map(s => s.trim()).filter(Boolean);
+  while (segs.length > 1) {
+    const toks = segs[segs.length - 1].toLowerCase().split(/\s+/).filter(Boolean);
+    if (toks.length && toks.every(t => AFF_GEO_WORDS.has(t))) segs.pop();
+    else break;
+  }
+  return segs[segs.length - 1] || (rawAff || '');
+}
+// OpenAlex が同定した機関名と Crossref 所属表記を照合し、誤同定の疑いを判定する。
+// (1) 機関名の有意トークンの過半数が所属表記に出現すれば整合とみなす（住所・メール等の
+//     雑多な文字列を含む実データでも、機関名が綴られていれば誤検出しない）。
+// (2) 過半数に満たない場合のみ、最上位組織名（末尾カンマセグメント）とのトークン共有を確認。
+//     どちらとも共有しなければ誤同定の疑いありとする。判定材料が無い場合は false（設定維持）。
+function isAffMisidentified(instName, rawAff) {
+  if (!rawAff) return false;
+  const instTokens = affNameTokens(instName);
+  if (!instTokens.length) return false;
+  const rawSet = new Set(affNameTokens(rawAff));
+  const matched = instTokens.filter(t => rawSet.has(t)).length;
+  if (matched * 2 > instTokens.length) return false;
+  const orgTokens = affNameTokens(topLevelOrgSegment(rawAff));
+  if (!orgTokens.length) return false;
+  return !orgTokens.some(t => instTokens.includes(t));
+}
+
 // ===== 4.3 著者マッピング =====
 function buildAuthors(crAuthors, oaAuthorships, rorMap) {
   // OpenAlex 著者を姓で索引化
@@ -2176,6 +2224,14 @@ function buildAuthors(crAuthors, oaAuthorships, rorMap) {
     const orcidId = orcidUri.replace(/^https?:\/\/orcid\.org\//i, '');
 
     // 所属: OpenAlex authorships[].institutions を使用
+    // OpenAlex 機関 id → 同定元の Crossref 所属表記 を対応付け（誤同定判定用）
+    const instIdToRaw = {};
+    (oaEntry?.affiliations || []).forEach(af => {
+      (af.institution_ids || []).forEach(id => {
+        if (id && !instIdToRaw[id]) instIdToRaw[id] = af.raw_affiliation_string || '';
+      });
+    });
+
     const oaInsts = oaEntry?.institutions || [];
     const affiliations = oaInsts.map(inst => {
       const rorUri = inst.ror || '';
@@ -2183,6 +2239,16 @@ function buildAuthors(crAuthors, oaAuthorships, rorMap) {
       const dispName = rorInfo.rorDisplayName || inst.display_name || '';
       const isni     = rorInfo.isni || '';
       const rorId    = rorInfo.rorId || '';
+
+      // 同定元の Crossref 所属表記と機関名を突合し、誤同定を判定
+      const rawAff = instIdToRaw[inst.id] || '';
+      if (rawAff && isAffMisidentified(inst.display_name || dispName, rawAff)) {
+        // 誤同定の疑い: ROR/ISNI を設定せず、Crossref の所属表記を機関名に採用（要編集）
+        return {
+          affiliationNames: [{ affiliationName: rawAff, affiliationNameLang: 'en', _warnLang: true, _warnAffNameRaw: true }],
+          affiliationNameIdentifiers: [],
+        };
+      }
 
       const affiliationNameIdentifiers = [];
       if (isni) affiliationNameIdentifiers.push({
@@ -2194,6 +2260,7 @@ function buildAuthors(crAuthors, oaAuthorships, rorMap) {
         affiliationNameIdentifier:       rorId,
         affiliationNameIdentifierScheme: 'ROR',
         affiliationNameIdentifierURI:    `https://ror.org/${rorId}`,
+        _warnRor: true,
       });
 
       return {
@@ -3946,7 +4013,10 @@ function renderOneAffiliation(aff, ai, keys, sfx) {
   }, sfx ? JPCOAR_SUBFIELD_LINKS[sfx + '_aff_name'] : undefined);
   (aff[affNameKey] || []).forEach(an => {
     const { grp, delBtn } = createEntryGroup();
-    grp.appendChild(createFieldRow('所属機関名', an[affNameField] || '', 'text', null, { fieldKey: affNameField }));
+    grp.appendChild(createFieldRow('所属機関名', an[affNameField] || '', 'text', null, {
+      fieldKey: affNameField, warn: an._warnAffNameRaw,
+      warnTitle: 'OpenAlex が同定した機関が Crossref の所属表記と一致しないため ROR を設定していません。記入は機関名までです。部局名など下位階層がある場合は編集してください。'
+    }));
     grp.appendChild(createFieldRow('言語', an[affNameLangField] || '', 'select', 'language', {
       fieldKey: affNameLangField, warn: an._warnLang, warnTitle: '仮に英語として設定しています。正確か確認してください'
     }));
@@ -4016,7 +4086,10 @@ function renderOneAffiliation(aff, ai, keys, sfx) {
         fieldKey: affIdSchemeField,
         onChange: () => updateAffLookup(),
       }));
-    aidContent.appendChild(createFieldRow('URI', aid[affIdUriField] || '', 'text', null, { fieldKey: affIdUriField }));
+    aidContent.appendChild(createFieldRow('URI', aid[affIdUriField] || '', 'text', null, {
+      fieldKey: affIdUriField, warn: aid._warnRor,
+      warnTitle: 'OpenAlex が機械同定した ROR です。正確か確認してください'
+    }));
 
     // (3) Scheme select が DOM にある状態で attachLookupUi を呼ぶ
     const { updateVisibility } = attachLookupUi({
@@ -6629,7 +6702,7 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-06-19';
+  const LOCAL_VERSION = '2026-06-22';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;


### PR DESCRIPTION
## 概要
Crossref が著者所属に ROR を持たない場合、本ツールは OpenAlex が機械同定した ROR を付与しているが、誤同定があるため対応する（[#165](https://github.com/tzhaya/jc-import-file-maker/issues/165)）。

- (1) OpenAlex 由来の ROR の URI 欄に「⚠ 要確認」バッジを常時表示（ORCID 同様）
- (2) OpenAlex の機関同定が Crossref 所属表記と一致しない誤同定の疑いを検出し、ROR を設定せず Crossref 所属表記を機関名として採用、機関名欄に注意喚起

## 背景
例（https://doi.org/10.3759/tropics.simm06 の 1st author）:
- Crossref 所属表記: `College of Fisheries and Marine Sciences, Aklan State University`
- OpenAlex が同定した機関: **`NOAA National Marine Fisheries Service`**（"Marine"/"Fisheries" の語が一致したための誤同定）

現状はこの誤った機関名・ROR がそのまま入力欄に流し込まれ、警告も出ない。

## 実装
- `buildAuthors()` 直前に判定ヘルパーを追加:
  - `affNameTokens()` — 汎用語（university/college/institute 等）と3文字未満を除いた有意トークンを抽出
  - `topLevelOrgSegment()` — Crossref 所属表記の最上位組織名（末尾カンマセグメント、末尾の国・地域名は除外）
  - `isAffMisidentified()` — **2段階判定**。(1) 機関名トークンの過半数が所属表記に出現すれば整合（住所・メール等を含む実データに強い）。(2) 過半数未満のときのみ最上位組織名とのトークン共有を確認し、共有しなければ誤同定の疑い
- `buildAuthors()`: `affiliations[].institution_ids` で機関 → 同定元 `raw_affiliation_string` を対応付け。誤同定時は ROR/ISNI を付与せず Crossref 所属表記を機関名に採用（`_warnAffNameRaw`）、正常時は ROR 識別子に `_warnRor`
- `renderOneAffiliation()`: ROR URI 欄に `_warnRor` バッジ、機関名欄に `_warnAffNameRaw` バッジ（ROR 未設定理由＋JPCOAR スキーマ準拠の「機関名まで編集」喚起）

## テスト（E2E ALL PASSED）
| DOI | 結果 |
|---|---|
| `10.3759/tropics.simm06` | Aklan→NOAA 誤同定を3著者分検出。正しい12 ROR は維持＋⚠バッジ。"National Institute of Meteorology"（meteorology 共有）は保守的に維持＋警告のみ |
| `10.1016/j.advnut.2025.100480`（JIRCAS、住所・メール付き raw） | 偽陽性なし。両著者の JIRCAS ROR を維持＋⚠バッジ |

※ 初回テストで JIRCAS の偽陽性リグレッションを発見し、最上位組織名のみの判定から過半数判定を前段に加えた2段階判定に改良した。

## 影響範囲・同期
- `make_jc_importer.html`（buildAuthors / renderOneAffiliation / 判定ヘルパー）
- `chrome-extension/make_jc_importer.js`（同期、ボタン追加なし）
- `make_jc_importer_test.html`（E2E 用、git 管理外）
- `chrome-extension/panel.html`（更新概要テーブル）
- `chrome-extension/manifest.json` version `1.11.1` → `1.12.0`（minor）、LOCAL_VERSION `2026-06-22`
- README.md / docs/requirements.md / docs/worklog.md / MEMORY.md 更新

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)