### PR TITLE
feat: CI品質チェック・文字コード前提の明文化 (#174, #175)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,9 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
+# TSV/CSV: 末尾タブが空列を表す場合があるため削除しない
+[*.{tsv,csv}]
+trim_trailing_whitespace = false
+
 [Makefile]
 indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# テキストファイルの改行を LF に統一
+* text=auto eol=lf
+
+# バイナリファイルは変換しない
+*.png binary
+*.zip binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run quality checks (JSON parse + JS syntax + UTF-8)
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 - [要件定義](docs/requirements.md)
 - [使い方ガイド](docs/user_guide.md)
+- [開発者向けドキュメント](docs/developer_docs.md) 品質チェック・文字コード確認・ドキュメント一覧。
 - [作業ログ](docs/worklog.md) 実装作業時のログです。
 - [APIフロー整理](api-flow.md) Crossref/OpenAlex等の取得順・JPCOARマッピングの概要です。
 - [機能と技術](function.md) 機能と技術、実装に関するドキュメントです。
@@ -355,6 +356,7 @@ CiNii APIキー未設定でも、以下の機能が動作します：
 
 | 日付 | 内容 |
 |------|------|
+| 2026-06-28 | CI品質チェック・文字コード明文化：`npm test` で JSON parse・JS構文・UTF-8妥当性を検証する `scripts/check.js` を追加。GitHub Actions の PR/push 時品質チェック（[`.github/workflows/ci.yml`](.github/workflows/ci.yml)）を追加。`.editorconfig`（`charset=utf-8`）・`.gitattributes` を追加。PowerShellでの文字化け確認手順・開発者向けドキュメント一覧（[`docs/developer_docs.md`](docs/developer_docs.md)）を整備（[#174](https://github.com/tzhaya/jc-import-file-maker/issues/174)・[#175](https://github.com/tzhaya/jc-import-file-maker/issues/175)） |
 | 2026-06-28 | ドキュメント整備：残存Issue一覧（[`docs/remaining_issues.md`](docs/remaining_issues.md)）を棚卸しし現状に同期（[#172](https://github.com/tzhaya/jc-import-file-maker/issues/172)）。完了済みIssue（#73/#112/#111/#116/#43/#4/#6 のほか #142/#143/#148/#159/#161/#165/#162、Phase 3 #157/#154/#155/#156）を「完了済みグループ」へ集約、OPEN節をGitHubの状態（#145/#169/#136/#123/#122/#95/#74/#8）に同期、概要・推奨実装順序・変更対象ファイル・実装時の参照ポイントを現構成に更新、OpenAlexパイプライン本格自動化（R2/R3/R4/R7）を「将来検討」として整理 |
 | 2026-06-28 | OpenAlex 起点 JAIRO Cloud 登録パイプラインの前段階（手動運用版・Phase 3）を実装（[#157](https://github.com/tzhaya/jc-import-file-maker/issues/157)）。(1) **DOIリスト一括取得**：複数DOIを改行/区切りで投入し順次取得→既存バッチに蓄積、失敗はスキップして集計表示（[#154](https://github.com/tzhaya/jc-import-file-maker/issues/154)）。(2) **OpenAlex機関別著作検索**：自機関 ROR で Works API を cursor paging 取得し候補一覧（掲載誌・出版日・OAバッジ・チェックボックス）を表示、選択DOIをコピー／（拡張）インポートタブへ受け渡し、検索・照合結果を自動保存・次回既定表示。標準版 `openalex_lookup.html`／Chrome拡張タブ（[#155](https://github.com/tzhaya/jc-import-file-maker/issues/155)）。(3) **登録済み照合バッジ**：候補タイトルで OpenSearch 検索→返戻 JPCOAR 内の識別子で DOI 照合し ⚪登録済みの可能性大（グレー）／🟡要確認／🟢未登録の可能性 の3値表示（Chrome拡張限定）（[#156](https://github.com/tzhaya/jc-import-file-maker/issues/156)）。あわせてタイトルの出版社XMLタグ片・改行を除去し、TSV全セルの制御文字を空白化してインポート時の行崩れを防止。manifest version `1.13.0` → `1.14.0` |
 | 2026-06-27 | 作業中データ（入力中・蓄積中のメタデータ）を自動保存し、タブ／サイドパネルを閉じても次回起動時に復元できる機能を追加（[#162](https://github.com/tzhaya/jc-import-file-maker/issues/162)）。Chrome拡張版は `chrome.storage.local`、スタンドアロン版は `localStorage` に保存（`shared.js` の `saveDraft`/`loadDraft`/`clearDraft`）。各バッチ操作後・フォーム編集のデバウンス（約1秒）・`visibilitychange`（タブ非表示）で自動保存し、起動時に下書きがあれば非ブロッキングのバナーで「復元／破棄」を提示。バッチパネルに「下書き削除」操作を追加。エクスポート後も下書きは保持。manifest version `1.12.0` → `1.13.0` |

--- a/docs/developer_docs.md
+++ b/docs/developer_docs.md
@@ -1,0 +1,67 @@
+# 開発者向けドキュメント
+
+初心者向けの使い方は [user_guide.md](user_guide.md) を参照してください。
+このドキュメントは保守・開発に必要な情報をまとめています。
+
+## 開発環境のセットアップ
+
+```
+git clone https://github.com/tzhaya/jc-import-file-maker.git
+cd jc-import-file-maker
+npm install
+```
+
+## 品質チェック（npm test）
+
+`npm test` を実行すると `scripts/check.js` が走り、以下を検証します:
+
+- **JSON parse**: `package.json` / `chrome-extension/manifest.json` が構文的に正しいか
+- **JS 構文チェック** (`node --check`): 自作 JS ファイル（`shared.js`、Chrome拡張の各 JS）に構文エラーがないか
+- **UTF-8 妥当性**: 上記ファイルおよび主要 Markdown が UTF-8 として正しく読めるか
+
+外部 API・APIキー・ネットワーク接続は不要です。PR 作成時は CI が自動で実行します（[.github/workflows/ci.yml](../.github/workflows/ci.yml)）。
+
+## 文字コードについて
+
+このリポジトリのテキストファイルは **UTF-8**（BOM なし）で保存されています（TSV エクスポート出力は UTF-8 BOM 付きですが、ソースコードは BOM なし）。`.editorconfig` で `charset = utf-8` を明示しています。
+
+### CLIや AI エージェントで日本語が文字化けして見える場合
+
+ファイルが壊れているのではなく、**表示環境のエンコーディング差**が原因である場合がほとんどです。
+
+**確認手順（Windows PowerShell）:**
+
+```powershell
+# UTF-8 として正しく読めるか確認
+Get-Content -Encoding UTF8 README.md | Select-Object -First 20
+
+# コンソール出力エンコーディングを UTF-8 に変更（セッション内のみ）
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::InputEncoding  = [System.Text.Encoding]::UTF8
+```
+
+**VS Code での確認:** エディタ右下のステータスバーにエンコーディングが表示されます（`UTF-8` であれば正常）。
+
+`npm test` の UTF-8 妥当性チェックが pass であれば、配布物は健全です。CLI 表示だけを根拠に日本語本文の一括復旧作業は行わないでください（[#175](https://github.com/tzhaya/jc-import-file-maker/issues/175)）。
+
+## ブランチ・PRワークフロー
+
+詳細は [CLAUDE.md](../CLAUDE.md) を参照してください。基本的に全変更でブランチを作成し、PR 経由でマージします。PR 作成直前は `/prepare-pr` チェックリストを実行してください。
+
+## リリース手順
+
+[docs/release_procedure.md](release_procedure.md) を参照してください。
+
+## ドキュメント一覧（保守者向け）
+
+| ドキュメント | 内容 |
+|---|---|
+| [requirements.md](requirements.md) | 要件定義 |
+| [fieldmapping.md](fieldmapping.md) | JPCOARフィールドマッピング |
+| [weko3_tsv_import_spec.md](weko3_tsv_import_spec.md) | WEKO3 TSVインポート仕様 |
+| [privacy-policy.md](privacy-policy.md) | プライバシーポリシー |
+| [release_procedure.md](release_procedure.md) | リリース手順 |
+| [remaining_issues.md](remaining_issues.md) | 残存Issue一覧 |
+| [worklog.md](worklog.md) | 実装作業ログ |
+| [api-flow.md](../api-flow.md) | Crossref/OpenAlex 取得フロー概要 |
+| [function.md](../function.md) | 機能と技術 |

--- a/docs/developer_docs.md
+++ b/docs/developer_docs.md
@@ -42,7 +42,7 @@ Get-Content -Encoding UTF8 README.md | Select-Object -First 20
 
 **VS Code での確認:** エディタ右下のステータスバーにエンコーディングが表示されます（`UTF-8` であれば正常）。
 
-`npm test` の UTF-8 妥当性チェックが pass であれば、配布物は健全です。CLI 表示だけを根拠に日本語本文の一括復旧作業は行わないでください（[#175](https://github.com/tzhaya/jc-import-file-maker/issues/175)）。
+`npm test` の UTF-8 妥当性チェックが pass であれば、チェック対象ファイルのエンコーディングは健全です。CLI 表示だけを根拠に日本語本文の一括復旧作業は行わないでください（[#175](https://github.com/tzhaya/jc-import-file-maker/issues/175)）。
 
 ## ブランチ・PRワークフロー
 

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,27 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-06-28（Phase 3 #157: OpenAlex起点パイプライン前段階）
+最終更新: 2026-06-28（CI品質チェック・文字コード明文化 #174/#175）
+
+## CI品質チェック・文字コード明文化（2026-06-28, #174 / #175）
+
+### 概要
+- `scripts/check.js` を新規追加。JSON parse・JS 構文（`node --check`）・UTF-8 妥当性の3種チェックを実行。外部 API・APIキー・ネットワーク不要。
+- `package.json` の `scripts.test` を `node scripts/check.js` に変更。
+- `.github/workflows/ci.yml` を追加。PR / push 時に `npm test` を自動実行。
+- `.editorconfig`（`charset=utf-8`）・`.gitattributes`（`text=auto eol=lf`）を新規追加。
+- `docs/developer_docs.md` を新規作成。品質チェック手順・PowerShell での UTF-8 確認手順・ドキュメント一覧を整備。
+- CLI/AI エージェントで日本語が文字化けして見える場合の確認手順を明文化（ファイル破損ではなく表示環境差）。
+
+### 変更ファイル
+- `scripts/check.js`（新規）
+- `package.json`（scripts.test 更新）
+- `.github/workflows/ci.yml`（新規）
+- `.editorconfig`（新規）
+- `.gitattributes`（新規）
+- `docs/developer_docs.md`（新規）
+- `README.md`（ドキュメントリンク追加・変更履歴追記）
+
+---
 
 ## OpenAlex起点パイプライン前段階・手動運用版（2026-06-28, Phase 3 #157 / #154 / #155 / #156）
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node scripts/check.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -33,9 +33,25 @@ const JS_FILES = [
 const UTF8_FILES = [
   ...JSON_FILES,
   ...JS_FILES,
+  // Markdown
   'README.md',
   'docs/privacy-policy.md',
   'docs/user_guide.md',
+  'docs/developer_docs.md',
+  // HTML (standalone)
+  'make_jc_importer.html',
+  'make_jc_importer_test.html',
+  'funder_lookup.html',
+  'funder_lookup_test.html',
+  'openalex_lookup.html',
+  // HTML (Chrome extension)
+  'chrome-extension/panel.html',
+  'chrome-extension/funder_panel.html',
+  'chrome-extension/openalex_panel.html',
+  'chrome-extension/opensearch_panel.html',
+  'chrome-extension/options.html',
+  // GitHub Pages
+  'docs/index.html',
 ];
 
 let errors = 0;

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Quality checks: JSON parse + JS syntax + UTF-8 validity for self-authored files.
+// Run via: npm test
+// Does NOT require network, API keys, or a browser.
+
+'use strict';
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const JSON_FILES = [
+  'package.json',
+  'chrome-extension/manifest.json',
+];
+
+const JS_FILES = [
+  'shared.js',
+  'tsv_headers_template.js',
+  'chrome-extension/background.js',
+  'chrome-extension/funder_lookup.js',
+  'chrome-extension/make_jc_importer.js',
+  'chrome-extension/openalex_panel.js',
+  'chrome-extension/opensearch_panel.js',
+  'chrome-extension/options.js',
+  'chrome-extension/shared.js',
+  'chrome-extension/tsv_headers_template.js',
+];
+
+// Text files that may contain Japanese — verify no encoding corruption (#175)
+const UTF8_FILES = [
+  ...JSON_FILES,
+  ...JS_FILES,
+  'README.md',
+  'docs/privacy-policy.md',
+  'docs/user_guide.md',
+];
+
+let errors = 0;
+
+function check(label, fn) {
+  try {
+    fn();
+    process.stdout.write(`  ✓ ${label}\n`);
+  } catch (e) {
+    process.stderr.write(`  ✗ ${label}: ${e.message}\n`);
+    errors++;
+  }
+}
+
+console.log('--- JSON parse ---');
+for (const f of JSON_FILES) {
+  check(f, () => {
+    const src = fs.readFileSync(path.join(ROOT, f), 'utf8');
+    JSON.parse(src);
+  });
+}
+
+console.log('--- JS syntax (node --check) ---');
+for (const f of JS_FILES) {
+  check(f, () => {
+    execFileSync(process.execPath, ['--check', path.join(ROOT, f)], { stdio: 'pipe' });
+  });
+}
+
+// TextDecoder with fatal:true throws on invalid byte sequences (#175)
+console.log('--- UTF-8 validity ---');
+const decoder = new TextDecoder('utf-8', { fatal: true });
+for (const f of UTF8_FILES) {
+  check(f, () => {
+    const buf = fs.readFileSync(path.join(ROOT, f));
+    decoder.decode(buf);
+  });
+}
+
+if (errors > 0) {
+  process.stderr.write(`\n${errors} check(s) failed.\n`);
+  process.exit(1);
+} else {
+  console.log('\nAll checks passed.');
+}

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -40,9 +40,7 @@ const UTF8_FILES = [
   'docs/developer_docs.md',
   // HTML (standalone)
   'make_jc_importer.html',
-  'make_jc_importer_test.html',
   'funder_lookup.html',
-  'funder_lookup_test.html',
   'openalex_lookup.html',
   // HTML (Chrome extension)
   'chrome-extension/panel.html',


### PR DESCRIPTION
## Summary

- `scripts/check.js` を追加: JSON parse / JS 構文 (`node --check`) / UTF-8 妥当性の3種チェックを一括実行。外部 API・APIキー・ネットワーク不要
- `package.json` の `scripts.test` を `node scripts/check.js` に変更（`exit 1` の常時失敗を解消）
- `.github/workflows/ci.yml` を追加: PR / push 時に `npm test` を自動実行
- `.editorconfig` (`charset=utf-8`)・`.gitattributes` (`text=auto eol=lf`) を追加
- `docs/developer_docs.md` を新規作成: 品質チェック手順・PowerShell での UTF-8 確認手順（CLI/AIエージェントでの文字化け誤検知対策）・開発者向けドキュメント一覧

Closes #174, #175

## Test plan

- [x] `npm test` がローカルで全 check pass（JSON / JS / UTF-8 全25件✓）
- [x] `docs/developer_docs.md` の手順を目視確認
- [ ] PR 後に CI workflow が pass することを GitHub Actions で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)