### PR TITLE
chore: skillにopenalex_lookup.html対応・npm testステップを追加

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: e2e-test
-description: Playwrightを使ってmake_jc_importer_test.htmlまたはfunder_lookup_test.htmlのE2Eテストを実行する。DOIや課題番号を入力し、取得結果のフィールドを検証する。
+description: Playwrightを使ってmake_jc_importer_test.html・funder_lookup_test.html・openalex_lookup.htmlのE2Eテストを実行する。DOI・課題番号・ROR IDを入力し、取得結果のフィールドを検証する。
 disable-model-invocation: true
-argument-hint: "[main | funder] [DOI or award number]"
+argument-hint: "[main | funder | openalex] [DOI / award number / ROR ID]"
 allowed-tools:
   - Bash
   - Read
@@ -27,12 +27,15 @@ npx playwright install chromium
 
 ## 引数
 
-- 第1引数: `main`（make_jc_importer_test.html、デフォルト）または `funder`（funder_lookup_test.html）
-- 第2引数: テスト対象の DOI または課題番号（省略時はデフォルト値を使用）
+- 第1引数: `main`（make_jc_importer_test.html、デフォルト）・`funder`（funder_lookup_test.html）・`openalex`（openalex_lookup.html）
+- 第2引数: テスト対象の DOI・課題番号・ROR ID（省略時はデフォルト値を使用）
 
 デフォルト値:
 - main: `10.1016/j.advnut.2025.100480`
 - funder: `JPMJPR2125`
+- openalex: `005pdtr14`（JIRCAS、#186検証実績のROR ID）
+
+> `openalex` はテスト版HTMLが存在しないため、本番の `openalex_lookup.html` を直接対象にする（同一フォルダの `shared.js` が必要。リポジトリ直下で実行すれば満たされる）。
 
 ## 重要: DOM セレクタの注意点
 
@@ -44,6 +47,12 @@ make_jc_importer_test.html の DOM 構造:
 - **データ取得完了の検知**: `#metadata-fields` の子要素数が 0 より大きくなるのを `waitForFunction` で待機する（`.person-card` や `#error-msg` の visible 待ちは不可）
 - **追加待機**: 非同期処理（助成情報のKAKEN/JGN取得、ROR取得等）があるため、metadata-fields 描画後に `waitForTimeout(5000)` で追加待機する
 - **ブラウザ起動オプション**: `chromium.launch({ headless: true, args: ['--disable-web-security'] })` を使用する（file:// からのAPI呼び出し対応）
+
+openalex_lookup.html の DOM 構造:
+- **ROR入力**: `#q-ror`、**対象日数**: `#q-days`（テストでは `30` 等の短い値にして結果件数を抑制する）、**検索ボタン**: `#btn-search`
+- **結果**: `#result-tbody` の `tr` が検索結果行（OpenAlexのページング取得があるため待機は長め・`timeout: 60000` 目安）
+- **件数メッセージ**: `#result-info`、**エラー**: `#error-msg`
+- **所属確認列（#186）**: `.col-warn`（要確認バッジの列）が存在するかで機能有無を確認できる
 
 ## テスト手順
 
@@ -217,11 +226,79 @@ const filePath = process.argv[3];
 })();
 ```
 
+#### openalex（openalex_lookup.html）の場合
+
+```javascript
+import { chromium } from 'playwright';
+
+const ror = process.argv[2] || '005pdtr14';
+const filePath = process.argv[3]; // openalex_lookup.html の絶対パス（本番HTMLを直接使用）
+
+(async () => {
+  const browser = await chromium.launch({ headless: true, args: ['--disable-web-security'] });
+  const page = await browser.newPage();
+
+  page.on('pageerror', err => console.error('PAGE ERROR:', err.message));
+
+  await page.goto(`file:///${filePath.replace(/\\/g, '/')}`);
+
+  // ROR入力 → 対象日数を絞る（結果件数抑制） → 検索ボタンクリック
+  await page.fill('#q-ror', ror);
+  await page.fill('#q-days', '30');
+  await page.click('#btn-search');
+
+  // 結果テーブルに行が描画されるのを待つ（OpenAlexページング取得のため長め）
+  try {
+    await page.waitForFunction(
+      () => document.querySelectorAll('#result-tbody tr').length > 0,
+      { timeout: 60000 }
+    );
+  } catch {
+    const errMsg = await page.textContent('#error-msg').catch(() => '');
+    const info = await page.textContent('#result-info').catch(() => '');
+    console.error('TIMEOUT: result-tbody still empty after 60s', { errMsg, info });
+    await browser.close();
+    process.exit(1);
+  }
+
+  const results = await page.evaluate(() => {
+    const rows = document.querySelectorAll('#result-tbody tr');
+    const rowCount = rows.length;
+    const infoText = document.getElementById('result-info')?.textContent || '';
+    const firstRowDoiLink = rows[0]?.querySelector('a[href*="doi.org"]')?.href || '';
+    const hasWarnColumn = document.querySelectorAll('#result-tbody .col-warn').length > 0;
+    return { rowCount, infoText, firstRowDoiLink, hasWarnColumn };
+  });
+
+  const checks = [
+    { field: '結果行数', ok: results.rowCount > 0, value: `${results.rowCount}件` },
+    { field: '件数メッセージ', ok: results.infoText.length > 0, value: results.infoText.substring(0, 80) || '(空)' },
+    { field: '1行目DOIリンク', ok: results.firstRowDoiLink.includes('doi.org'), value: results.firstRowDoiLink || 'なし' },
+    { field: '所属確認列(#186)', ok: results.hasWarnColumn, value: results.hasWarnColumn ? 'あり' : 'なし' },
+  ];
+
+  console.log('\n=== E2E テスト結果 (openalex) ===');
+  console.log(`ROR: ${ror}\n`);
+  let allPassed = true;
+  for (const c of checks) {
+    const mark = c.ok ? 'PASS' : 'FAIL';
+    if (!c.ok) allPassed = false;
+    console.log(`[${mark}] ${c.field}: ${c.value}`);
+  }
+
+  console.log(`\n結果: ${allPassed ? 'ALL PASSED' : 'SOME FAILED'}`);
+  await browser.close();
+  process.exit(allPassed ? 0 : 1);
+})();
+```
+
 ### 2. テストの実行
 
 ```bash
-node _e2e_test.mjs <DOIまたは課題番号> <テスト用HTMLの絶対パス>
+node _e2e_test.mjs <DOI・課題番号・ROR ID> <対象HTMLの絶対パス>
 ```
+
+openalex の場合、`<対象HTMLの絶対パス>` は本番の `openalex_lookup.html`（テスト版なし）。
 
 ### 3. main テスト時の funder 連携テスト
 
@@ -252,7 +329,7 @@ node _e2e_test_funder.mjs "JP19KK0341" "/path/to/funder_lookup_test.html"
 
 ### 5. クリーンアップ
 
-テスト完了後、一時スクリプト `_e2e_test.mjs` および `_e2e_test_funder.mjs` を削除してください。
+テスト完了後、一時スクリプト `_e2e_test.mjs`・`_e2e_test_funder.mjs`・`_e2e_test_openalex.mjs` を削除してください。
 
 ### 6. 結果報告
 

--- a/.claude/skills/prepare-pr/SKILL.md
+++ b/.claude/skills/prepare-pr/SKILL.md
@@ -19,6 +19,8 @@ argument-hint: "(任意のメモ)"
 | `make_jc_importer.html` | `make_jc_importer_test.html` |
 | `funder_lookup.html` | `funder_lookup_test.html` |
 
+> `openalex_lookup.html` にはテスト版が存在しない（単一ファイル運用）。変更した場合は `/e2e-test openalex` で本番HTMLを直接対象にテストする。
+
 同期後、ユーザーに `/e2e-test` の手動実行を依頼する（Claudeからは起動不可）。
 **ALL PASSED になるまでPR作成に進まない。**
 
@@ -36,6 +38,7 @@ argument-hint: "(任意のメモ)"
   - `chrome-extension/funder_lookup.js` に変更を反映（CONFIGのAPIキーは残す）
 - `shared.js` を変更した場合 → `chrome-extension/shared.js` に同一内容をコピー
 - `tsv_headers_template.js` を変更した場合 → `chrome-extension/tsv_headers_template.js` に同一内容をコピー
+- `openalex_lookup.html` を変更した場合 → `chrome-extension/openalex_panel.js` / `chrome-extension/openalex_panel.html` に同一ロジックを反映（CONFIGはshared.js経由のため個別のAPIキー置換は不要）。「最終更新」表記・LOCAL_VERSIONは無い
 
 > 本番HTML/共有JSを編集すると `sync-reminder` フックが同期先を即時リマインドする。
 
@@ -47,6 +50,7 @@ argument-hint: "(任意のメモ)"
 - `funder_lookup.html` → `chrome-extension/funder_lookup.js`
 
 未更新だと「新しいバージョンがあります」が誤表示される。
+（`openalex_lookup.html` は `checkForUpdate()` を持たないため対象外）
 
 ## 4. `chrome-extension/manifest.json` の `version` 更新
 
@@ -59,12 +63,18 @@ Chrome拡張配下（`make_jc_importer.js` / `funder_lookup.js` / `panel.html` /
 ## 5. ドキュメント更新
 
 - `README.md`:
-  - 「最新の更新」テーブル: 3ツール（Chrome拡張版 / インポート用TSV生成ツール / 助成情報検索ツール）の日付・バージョン・更新概要を更新。Chrome拡張版のみバージョン列に `ver. X.Y.Z`、他は `—`
+  - 「最新の更新」テーブル: 4ツール（Chrome拡張版 / インポート用TSV生成ツール / 助成情報検索ツール / OpenAlex機関別著作検索）の日付・バージョン・更新概要を更新。Chrome拡張版のみバージョン列に `ver. X.Y.Z`、他は `—`
   - 変更履歴テーブルに日付と内容を追記（新しい日付が上）
 - `docs/requirements.md`: 機能追加・変更があれば要件定義を更新
 - `docs/worklog.md`: 最終更新日・実装内容の詳細セクションを追記
 - `MEMORY.md`: 行番号目安・ファイル規模など該当箇所を更新
 
-## 6. PR作成
+## 6. 品質チェック（`npm test`）
+
+`npm test`（`scripts/check.js`: JSON parse + JS構文 + UTF-8妥当性 + 手動同期ファイルの一致チェック + TSVヘッダー構造チェック）を実行し、**ALL PASSしてからPR作成に進む**。
+
+特に `shared.js` / `tsv_headers_template.js` を編集した場合、`chrome-extension/` 側へのコピー忘れはここで検出される（#193）。
+
+## 7. PR作成
 
 ブランチ運用ルール（CLAUDE.md）に従い `gh pr create` でPRを作成する。

--- a/.claude/skills/sync-test/SKILL.md
+++ b/.claude/skills/sync-test/SKILL.md
@@ -23,6 +23,8 @@ allowed-tools:
 | `make_jc_importer.html` | `make_jc_importer_test.html` |
 | `funder_lookup.html` | `funder_lookup_test.html` |
 
+> `openalex_lookup.html` はテスト版が存在しないため本スキルの対象外。
+
 ## 引数
 
 - `all`（デフォルト、引数なし時も同様）: 両方を同期


### PR DESCRIPTION
## Summary
- prepare-pr / e2e-test / sync-test skillが #186 (openalex_lookup.html 追加) と #193 (npm testでの手動同期ファイル一致チェック追加) 以降の実態を反映していなかったため更新
- e2e-test に openalex モードを追加（テスト版が無い openalex_lookup.html を直接対象に、ROR入力→検索→結果行/所属確認列(#186)を検証）
- prepare-pr に openalex_lookup.html の拡張版同期先（chrome-extension/openalex_panel.js / openalex_panel.html）を明記、README「4ツール」表記に修正、PR作成前の npm test 実行ステップを追加
- sync-test に openalex_lookup.html が対象外である旨を注記

なお `.claude/hooks/sync-reminder.mjs`（openalex_lookup.html編集時の同期リマインダー追加）はローカル専用設定（.gitignoreで`.claude/**`除外、`.claude/skills/`のみ例外）のため本PRには含まれません。ローカルでは動作確認済みです。

## Test plan
- [x] `npm test` が ALL PASS することを確認
- [x] e2e-test の openalex テストスクリプト例を実際に openalex_lookup.html に対して実行し ALL PASSED を確認（ROR: 005pdtr14 / JIRCAS、11件検出・要確認1件・所属確認列あり）
- [x] sync-reminder.mjs の新規エントリが openalex_lookup.html で発火し、chrome-extension配下や_test.htmlでは従来通り発火しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)