### PR TITLE
fix: 不正URL時にsendResponseが呼ばれずハングする問題を修正 (#195)

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -21,7 +21,9 @@ chrome.runtime.onMessage.addListener((req, sender, sendResponse) => {
 
   // ホワイトリストチェック: 許可されたホストのみプロキシ
   if (!ALLOWED_HOSTS.some(host => req.url.startsWith(host))) {
-    sendResponse({ error: `Blocked: ${new URL(req.url).host} is not in the allowed hosts list` });
+    let host = req.url;
+    try { host = new URL(req.url).host; } catch { /* 不正なURL文字列はそのまま表示 */ }
+    sendResponse({ error: `Blocked: ${host} is not in the allowed hosts list` });
     return true;
   }
 

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -19,6 +19,11 @@ const ALLOWED_HOSTS = [
 chrome.runtime.onMessage.addListener((req, sender, sendResponse) => {
   if (req.type !== 'FETCH') return false;
 
+  if (typeof req.url !== 'string') {
+    sendResponse({ error: 'Blocked: request url must be a string' });
+    return true;
+  }
+
   // ホワイトリストチェック: 許可されたホストのみプロキシ
   if (!ALLOWED_HOSTS.some(host => req.url.startsWith(host))) {
     let host = req.url;


### PR DESCRIPTION
## Summary
- `background.js` のfetchプロキシで、ホワイトリスト外URLのエラー応答生成時に `new URL(req.url).host` を評価しており、`req.url` が不正なURL文字列だと例外が発生し `sendResponse` が呼ばれないまま終了していた
- try/catchで囲み、失敗時はURL文字列そのものをエラーメッセージに使うよう修正

Closes #195

## Test plan
- [x] `npm test`（`scripts/check.js`）ALL PASS
- [x] `node --check chrome-extension/background.js` 構文チェックOK
- 本修正はエラーハンドリングのみで通常経路の挙動に影響しないため、E2Eテスト（main/funder/openalex）は対象外と判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)