### PR TITLE
docs: JaLC所属機関検索に関する記述を現行APIに整合させる (#191)

### DIFF
--- a/docs/cinii_research_api_feasibility.md
+++ b/docs/cinii_research_api_feasibility.md
@@ -28,9 +28,9 @@
   照合を標準ブラウザ版にも広げられる**点。ただし CiNii は IRDB ハーベストのため**鮮度に遅延**があり、
   #156 の核心的利点「リポジトリ現在状態への問い合わせで**状態の同期ずれが起きない**」が失われる。
   → **置換ではなく補完**（標準版向け／全国横断の重複アウェアネス）が妥当。
-- **問い B**：**CiNii Research 一択**。JaLC はデータに著者所属を持たず、所属機関での検索が原理的に
-  成立しない。ただし CiNii でも自由文 affiliation 検索は不確実なため、堅牢なのは
-  **researcher（NRID／KAKEN 研究者ID／researchmap）経由**。JaLC は捕捉エンジンではなく
+- **問い B**：**CiNii Research 一択**。JaLC は所属機関（affiliation）の検索機能を備えているが、
+  実データの affiliation 登録が任意（登録者依存）のため、検索効率では
+  **researcher（NRID／KAKEN 研究者ID／researchmap）経由が主軸**。JaLC は捕捉エンジンではなく
   **per-DOI のメタデータ源**として既存どおり残す。
 
 ---
@@ -127,9 +127,11 @@ publisher＝機関だが、**J-STAGE 和文誌は publisher＝学会**であり�
 
 ### API 能力
 
-- **JaLC REST API**：2026-03-25 に `/search` エンドポイントが追加され、**著者名・タイトル・PID**で
-  検索できる。しかし**所属機関（affiliation）は検索項目に無い**（そもそもデータに無い）。
-  本ツールは既に `v2/dois/{doi}` 単件取得を利用（`make_jc_importer.js:907`、CORS 制約で拡張版のみ）。
+- **JaLC REST API**：2026-03-25 に `/search` エンドポイントが追加され、**著者名・タイトル・PID**に加え
+  **所属機関（affiliation）での検索も可能**（フィールド検索 `query.affiliation` ・
+  ID フィルタ `filter=affiliation-identifier`）。ただし実データの affiliation 登録は任意のため、
+  実際の検索効率は affiliation 登録率に左右される。本ツールは既に `v2/dois/{doi}` 単件取得を利用
+  （`make_jc_importer.js:907`、CORS 制約で拡張版のみ）。
 - **CiNii Research OpenSearch**：`authorid`（NRID）パラメータ対応・`q` で Author ID 検索可。
   和文誌・紀要・IR（IRDB 経由）・CiNii Articles・KAKEN を集約＝**捕捉したい母集団そのもの**を含む。
   CORS 対応・JSON-LD・DOI フィールドあり（本ツールで既利用）。
@@ -138,7 +140,7 @@ publisher＝機関だが、**J-STAGE 和文誌は publisher＝学会**であり�
 
 | 観点 | (A) JaLC 所属機関検索 | (B) CiNii Research |
 |------|----------------------|--------------------|
-| 所属機関での検索 | **不可**（データに著者所属なし／検索項目にもなし） | researcher-ID(NRID) 経由で実質可。自由文 affiliation は弱い |
+| 所属機関での検索 | **可能**（`query.affiliation` / `filter=affiliation-identifier` ）。ただし affiliation 登録は任意 | researcher-ID(NRID) 経由で実質可。自由文 affiliation は弱い |
 | 対象コーパス | JaLC 登録分（登録元単位） | 和文誌・紀要・IR・CiNii Articles・KAKEN を**横断集約** |
 | 機関の手掛かり | publisher/site＝登録元（学会誌では著者所属と無関係） | 著者→研究者→機関のリンク（KAKEN/researchmap 連携） |
 | CORS / 実行環境 | 拡張版のみ（プロキシ経由） | **標準版でも可**（既実証） |
@@ -146,8 +148,8 @@ publisher＝機関だが、**J-STAGE 和文誌は publisher＝学会**であり�
 
 ### 結論・推奨
 
-1. **「所属機関で検索」する捕捉エンジンとしては CiNii Research 一択。** JaLC は著者所属を持たず、
-   `/search` も著者名・タイトル・PID 止まりで、所属機関検索は原理的に成立しない。
+1. **「所属機関で検索」する捕捉エンジンとしては CiNii Research が主軸。** JaLC も所属機関検索機能を備えるが、
+   実データの affiliation 登録率が低く（登録は任意）検索効率が限定的。堅牢な捕捉には researcher 経由が推奨。
 2. **ただし CiNii も自由文の affiliation 検索は不確実。** 和文メタデータは所属が疎なため、堅牢なのは
    **researcher 経由**：自機関の研究者リスト（NRID／KAKEN 研究者ID／researchmap）を起点に
    CiNii Research（`authorid`）や KAKEN で各研究者の業績 DOI を引く。

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,30 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-07-03（OpenAlex機関別著作検索の外部リンクタブ復帰不具合を修正 #201）
+最終更新: 2026-07-03（JaLC所属機関検索に関するドキュメント訂正 #191）
+
+## JaLC所属機関検索に関するドキュメント訂正（2026-07-03, #191）
+
+### 概要
+`docs/cinii_research_api_feasibility.md` §B（JaLC DOI論文の捕捉）の記述が、JaLC REST APIの公式OpenAPI仕様（`https://api.japanlinkcenter.org/v3/api-docs`）および実クエリ検証結果と矛盾していた。「JaLCは所属機関検索が不可（原理的に成立しない）」という記述を、現行API仕様に整合させる訂正を実施した。
+
+### 検出理由
+Issue #190（JaLC起点パイプライン実装計画作成）の事前調査で、JaLC REST APIの `/search` エンドポイントが `query.affiliation`（フィールド検索）・`filter=affiliation-identifier`（ROR等によるIDフィルタ）を公式に提供していること、実クエリで実際にヒット件数が返されること（例: `filter=affiliation-identifier:005pdtr14` で JIRCAS対応の12件、`query.affiliation=Japan International Research Center...` で1,468件）を確認。同時に `v2/dois/{doi}` レスポンス実例で `creator_list[].affiliation_list[]` に ROR URI を含むデータが実在することを確認した。
+
+### 変更内容
+- **TL;DR（L31-34）**: 「所属機関検索が原理的に成立しない」を「検索機能を備えているが、実データの affiliation 登録が任意（登録者依存）のため、検索効率では researcher 経由が主軸」に訂正
+- **API能力セクション（L130-134）**: 「所属機関（affiliation）は検索項目に無い」を「所属機関での検索も可能（`query.affiliation` フィールド検索・`filter=affiliation-identifier` ID フィルタ）。ただし実データの affiliation 登録は任意のため、実際の検索効率は affiliation 登録率に左右される」に訂正
+- **評価表（L143）**: 「不可（データに著者所属なし／検索項目にもなし）」を「可能（`query.affiliation` / `filter=affiliation-identifier`）。ただし affiliation 登録は任意」に訂正
+- **結論・推奨（L151-152）**: 「JaLC は著者所属を持たず、所属機関検索は原理的に成立しない」を「JaLC も所属機関検索機能を備えるが、実データの affiliation 登録率が低く（登録は任意）検索効率が限定的。堅牢な捕捉には researcher 経由が推奨」に訂正
+
+### 注意事項
+- ドキュメント修正のみで、本番HTML・共有JS・Chrome拡張コードの変更は無い
+- #190（JaLC起点パイプライン実装計画）の設計根拠となるため、実装より先行して修正
+- `docs/Implementation_JaLC.md` の `buildJaLCAuthors`（実装コード L1932-1941）および affiliation 設計は実データで検証済みのため、修正不要
+
+### 検証
+`npm test` で全チェック（JSON parse・JS構文・UTF-8妥当性・ファイル同期・TSVヘッダー構造）がPASS。
+
+---
 
 ## OpenAlex機関別著作検索の外部リンクタブ復帰不具合を修正（2026-07-03, #201）
 


### PR DESCRIPTION
## Summary

docs/cinii_research_api_feasibility.md §B（JaLC DOI論文の捕捉）の記述が、JaLC REST APIの公式OpenAPI仕様および実クエリ検証結果と矛盾していました。

**検出内容:**
- 公式OpenAPI仕様：`query.affiliation`（フィールド検索）・`filter=affiliation-identifier`（IDフィルタ）を提供
- 実クエリ検証：`filter=affiliation-identifier:005pdtr14`（JIRCAS） → 12件ヒット、`query.affiliation=...` → 1,468件ヒット
- 実レスポンス（`v2/dois/{doi}`）：`creator_list[].affiliation_list[]` に ROR URI を含むデータが実在

**修正内容:**
1. TL;DR§B（L31-34）：「所属機関検索が原理的に成立しない」→「検索機能を備えているが、affiliation登録が任意のため、researcher経由が主軸」に訂正
2. API能力セクション（L130-134）：「検索項目に無い」→「検索も可能。ただしaffiliation登録は任意」に訂正、登録率の制限を明記
3. 評価表（L143）：「不可」→「可能（`query.affiliation` / `filter=affiliation-identifier`）。ただしaffiliation登録は任意」に修正
4. 結論・推奨（L151-152）：同様に訂正、researcher経由が推奨という方針を明確化
5. docs/worklog.md に実装記録を追記

**背景:**
この修正は Issue #190（JaLC起点パイプライン実装計画）の設計根拠となるため、実装より先行して対応しました。

**注意事項:**
- ドキュメント修正のみ（HTML・共有JS・Chrome拡張コードなし）
- E2Eテスト対象外・manifestバージョン更新不要（#196と同型）
- `docs/Implementation_JaLC.md` の実装コードは実データ検証済みのため修正不要
- npm test: ALL PASSED

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)