### PR TITLE
test: 純粋関数の単体テストを追加（node:test）（#192）

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ DOIを入力してCrossref・OpenAlex APIから書誌情報を取得し、[JAIRO
 
 | ツール | 日付 | バージョン | 更新概要 |
 |--------|------|-----------|----------|
-| Chrome拡張機能版 | 2026-07-04 | ver. 1.19.0 | DataCite DOIパスにOPF連動によるアクセス権エンバーゴ判定を追加（[#214](https://github.com/tzhaya/jc-import-file-maker/issues/214)） |
-| インポート用TSV生成ツール | 2026-07-04 | — | DataCite DOIパスにOPF連動によるアクセス権エンバーゴ判定を追加。OAステータスがclosed/未収録の場合にOPFエンバーゴの有無でembargoed access/open accessを判定（Crossref/JaLCパスと同様）（[#214](https://github.com/tzhaya/jc-import-file-maker/issues/214)） |
+| Chrome拡張機能版 | 2026-07-05 | ver. 1.19.1 | DOI入力の正規化が `https://dx.doi.org/…` 形式にも対応。あわせて純粋関数の単体テスト基盤（node:test）を整備（[#192](https://github.com/tzhaya/jc-import-file-maker/issues/192)） |
+| インポート用TSV生成ツール | 2026-07-05 | — | DOI入力の正規化が `https://dx.doi.org/…` 形式にも対応（従来の `https://doi.org/…`・`doi:…` に加えて）（[#192](https://github.com/tzhaya/jc-import-file-maker/issues/192)） |
 | 助成情報検索ツール | 2026-06-11 | — | マルチバイト文字列（日本語）を含む行から課題番号を抽出できないバグを修正（[#149](https://github.com/tzhaya/jc-import-file-maker/issues/149)）。検索結果の外部リンクをクリックするとツールがリロードされる不具合を修正（[#150](https://github.com/tzhaya/jc-import-file-maker/issues/150)） |
 | OpenAlex機関別著作検索 | 2026-07-03 | — | 検索結果の外部リンクをクリックするとタブが「DOIインポート」に戻る不具合を修正（[#201](https://github.com/tzhaya/jc-import-file-maker/issues/201)）。所属の誤判定が疑われる候補に「⚠ 要確認」バッジを表示（[#186](https://github.com/tzhaya/jc-import-file-maker/issues/186)） |
 
@@ -301,6 +301,7 @@ Service Worker の fetch proxy は `ALLOWED_HOSTS`（KAKEN・JaLC・OPF の3ホ�
 
 | 日付 | 内容 |
 |------|------|
+| 2026-07-05 | 純粋関数の単体テストを追加（[#192](https://github.com/tzhaya/jc-import-file-maker/issues/192)）：依存ゼロの Node 組み込み `node:test` で、DOM に依存しない純粋関数（`normalizeDoi`/`isValidDoi`/`processAbstract`/`generateTsv`/`detectAffMisattribution` 等）の単体テストを `tests/` に整備し、`npm test`（CI含む）に組み込み。テストから `require` できるよう `chrome-extension/make_jc_importer.js`・`openalex_panel.js` に `typeof window`／`typeof document`／`module.exports` ガードを追加（ブラウザ動作は不変）。あわせて `make_jc_importer` の DOI 正規化を `funder_lookup` に合わせ `https://dx.doi.org/…` 対応へ統一（実挙動変更）。標準版・Chrome拡張版に同一実装。manifest version `1.19.0` → `1.19.1` |
 | 2026-07-05 | Codexによる現状レビュー（進捗・実用性・将来拡張可能性・課題）を [`docs/current_review_2026-07-05.md`](docs/current_review_2026-07-05.md) として保存。新規ドキュメント追加ルールに従い、`scripts/check.js` の UTF-8 チェック対象と `docs/developer_docs.md` のドキュメント一覧にも登録。ドキュメント中心の変更（本番HTML・共有JS・Chrome拡張コードの変更なし、E2E対象外・manifest更新不要） |
 | 2026-07-05 | 開発者向けドキュメント（[`docs/developer_docs.md`](docs/developer_docs.md)）に「テストの限界と教訓」節（Nodeサンドボックス検証はDOM描画を見ない・標準版E2Eでは拡張版限定機能を検出できない・仕様書の除外規則は実装チェックリスト化する、の3点を実例付きで整理）と「テスト用DOIカタログ」節（回帰・E2Eで使う代表DOIと各々の検証観点）を追加。保守者向けドキュメントのみの変更（本番HTML・共有JS・Chrome拡張コードの変更なし） |
 | 2026-07-04 | DataCite DOIパスにOPF連動によるアクセス権エンバーゴ判定を追加（[#214](https://github.com/tzhaya/jc-import-file-maker/issues/214)）：#212のフォローアップ。処理順を「ISSN早期抽出（新設 `extractDataCiteIssnsFromRaw`／`findDataCiteSourceIdentifier`、`extractDataCiteBibliographicInfo`と抽出優先順位を共通化）→OPF取得→マッピング」に変更し、Crossref/JaLCパスと同じ `determineAccessRights(oaStatus, lastOpfData)` をDataCiteパスでも呼び出すことで、従来固定していた `open access` をOAステータスがclosed/未収録の場合にOPFエンバーゴの有無で `embargoed access`/`open access` に判定するよう変更。効果はOPF照会が有効なChrome拡張版のみ（標準版はOPF無効のため無回帰）。標準版・Chrome拡張版に同一実装。manifest version `1.18.0` → `1.19.0` |

--- a/chrome-extension/make_jc_importer.js
+++ b/chrome-extension/make_jc_importer.js
@@ -4,13 +4,14 @@
 // ================================================================
 // CONFIG, loadConfig(), extensionFetch() は shared.js で定義
 // TSV_HEADERS_TEMPLATE は tsv_headers_template.js で定義
-if (typeof CONFIG === 'undefined') {
+// （typeof window ガードは #192 ユニットテストで Node から require するため。ブラウザでは従来どおり動作）
+if (typeof CONFIG === 'undefined' && typeof window !== 'undefined') {
   console.warn('shared.js が読み込めませんでした。APIキーなしで動作します。');
   window.CONFIG = { OpenAlex_API_KEY: '', CiNii_API_KEY: '', OPF_API_KEY: '' };
   window.loadConfig = async function() {};
   window.extensionFetch = function(url, options) { return fetch(url, options); };
 }
-if (typeof TSV_HEADERS_TEMPLATE === 'undefined') {
+if (typeof TSV_HEADERS_TEMPLATE === 'undefined' && typeof window !== 'undefined') {
   console.warn('tsv_headers_template.js が読み込めませんでした。TSV出力は使用できません。');
   window.TSV_HEADERS_TEMPLATE = null;
 }
@@ -847,7 +848,7 @@ function renderSystemFields(systemData) {
 // ===== DOI 正規化 =====
 function normalizeDoi(raw) {
   return raw.trim()
-    .replace(/^https?:\/\/doi\.org\//i, '')
+    .replace(/^https?:\/\/(dx\.)?doi\.org\//i, '')
     .replace(/^doi:/i, '')
     .trim();
 }
@@ -6998,6 +6999,11 @@ function closePreview() {
   document.body.style.overflow = '';
 }
 
+// ===== 以下、DOM 配線・初期化（ブラウザ実行時のみ実行） =====
+// #192: ユニットテストで Node から require できるよう、DOM に触れる実行文を
+// typeof document ガードで包む。関数宣言はホイストのためガード外（トップレベル）に残す。
+if (typeof document !== 'undefined') {
+
 document.addEventListener('keydown', e => {
   if (e.key === 'Escape') { closePreview(); closeOpfModal(); }
 });
@@ -7134,6 +7140,8 @@ document.getElementById('doi-input').addEventListener('keydown', e => {
   await maybeShowDraftBanner();
 })();
 
+}  // end typeof document ガード（DOM 配線・初期化） #192
+
 // ===== 下書き復元バナー制御（#162） =====
 let pendingDraft = null;
 
@@ -7171,8 +7179,8 @@ function restoreDraft() {
 }
 
 // ===== 更新チェック =====
-(async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-07-04';
+if (typeof document !== 'undefined') (async function checkForUpdate() {
+  const LOCAL_VERSION = '2026-07-05';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;
@@ -7189,3 +7197,9 @@ function restoreDraft() {
     }
   } catch (_) { /* オフライン時は静かに無視 */ }
 })();
+
+// ===== ユニットテスト用エクスポート（#192） =====
+// Node（node:test）から純粋関数を require するためのガード。ブラウザでは module 未定義のため不活性。
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { normalizeDoi, isValidDoi, processAbstract, generateTsv };
+}

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JAIRO Cloud インポート支援ツール",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "JAIRO Cloud（WEKO3）に登録するメタデータの作成とインポートを支援するChrome拡張機能です。DOIを入力するだけで、Crossref / JaLC / DataCite / OpenAlex から書誌メタデータを自動で取得します。",
   "icons": {
     "16": "icons/icon16.png",

--- a/chrome-extension/openalex_panel.js
+++ b/chrome-extension/openalex_panel.js
@@ -8,7 +8,8 @@
 // ============================================================
 
 // shared.js 未読込時のフォールバック（標準HTMLを単体配布した場合の保険）
-if (typeof CONFIG === 'undefined') {
+// （typeof window ガードは #192 ユニットテストで Node から require するため。ブラウザでは従来どおり動作）
+if (typeof CONFIG === 'undefined' && typeof window !== 'undefined') {
   console.warn('shared.js が読み込めませんでした。フォールバック設定で動作します。');
   window.CONFIG = { OpenAlex_API_KEY: '', DEFAULT_ROR_ID: '', DEFAULT_OPENALEX_DAYS: 90 };
   window.loadConfig = async function () {};
@@ -818,4 +819,13 @@ if (IS_CHROME_EXTENSION) {
   });
 }
 
-document.addEventListener('DOMContentLoaded', init);
+// #192: ユニットテストで Node から require できるよう、DOM 依存の初期化登録をガード。
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', init);
+}
+
+// ===== ユニットテスト用エクスポート（#192） =====
+// Node（node:test）から純粋関数を require するためのガード。ブラウザでは module 未定義のため不活性。
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { detectAffMisattribution, warnTooltip, canonicalRor, affStringSupportsInst };
+}

--- a/chrome-extension/panel.html
+++ b/chrome-extension/panel.html
@@ -501,7 +501,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-07-04 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-07-05 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -513,6 +513,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-07-05</td>
+        <td style="padding:2px 0;">Chrome拡張 ver. 1.19.1：DOI入力の正規化が <code>https://dx.doi.org/…</code> 形式にも対応（従来の <code>https://doi.org/…</code>・<code>doi:…</code> に加えて）（#192）。あわせて純粋関数の単体テスト基盤（node:test）を整備</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-07-04</td>
         <td style="padding:2px 0;">Chrome拡張 ver. 1.19.0：DataCite DOIパスにOPF連動によるアクセス権エンバーゴ判定を追加。OAステータスがclosed/未収録の場合にOPFエンバーゴの有無でembargoed access/open accessを判定（Crossref/JaLCパスと同様）（#214）</td>
@@ -528,10 +532,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-07-02</td>
         <td style="padding:2px 0;">Chrome拡張 ver. 1.16.0：DOIリスト一括取得の実行中に「中断」ボタンを表示し、押下でループを安全に停止できるように（中断前までの成功分は蓄積アイテムに保持）（#194）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-28</td>
-        <td style="padding:2px 0;">Chrome拡張 ver. 1.14.0：OpenAlex機関別著作検索タブを追加（自機関RORで候補論文を検索→登録済み照合バッジ→選択DOIをインポートタブへ受け渡し、検索結果を自動保存）（#155/#156）。DOIリストの一括取得を追加（#154）。タイトルのタグ片・改行を除去しTSVの行崩れを防止</td>
       </tr>
     </tbody>
   </table>

--- a/docs/developer_docs.md
+++ b/docs/developer_docs.md
@@ -13,13 +13,34 @@ npm install
 
 ## 品質チェック（npm test）
 
-`npm test` を実行すると `scripts/check.js` が走り、以下を検証します:
+`npm test` を実行すると `scripts/check.js`（静的チェック）と `node --test`（ユニットテスト）が順に走り、以下を検証します:
 
 - **JSON parse**: `package.json` / `package-lock.json` / `chrome-extension/manifest.json` / `data/tsv_headers.json` が構文的に正しいか
-- **JS 構文チェック** (`node --check`): 自作 JS ファイル（`shared.js`、Chrome拡張の各 JS）に構文エラーがないか
+- **JS 構文チェック** (`node --check`): 自作 JS ファイル（`shared.js`、Chrome拡張の各 JS、`tests/*.test.js`）に構文エラーがないか
 - **UTF-8 妥当性**: 上記ファイルおよび主要 Markdown が UTF-8 として正しく読めるか
+- **ファイル同期**: `shared.js` ↔ `chrome-extension/shared.js` 等の同期ペアが一致しているか
+- **ユニットテスト** (`node --test "tests/**/*.test.js"`): 副作用のない純粋関数の振る舞い（下記）
 
 外部 API・APIキー・ネットワーク接続は不要です。PR 作成時は CI が自動で実行します（[.github/workflows/ci.yml](../.github/workflows/ci.yml)）。
+
+### ユニットテスト（node:test・[#192](https://github.com/tzhaya/jc-import-file-maker/issues/192)）
+
+依存ゼロの Node 組み込み `node:test` + `node:assert` で、DOM に依存しない純粋関数を検証します。テストは `tests/` にあり、`node --test "tests/**/*.test.js"` で単体実行できます（`npm test` からも自動実行）。
+
+| テストファイル | 対象関数 | 主な検証内容 |
+| --- | --- | --- |
+| `tests/doi.test.js` | `normalizeDoi` / `isValidDoi` | URL・`dx.doi.org`・`doi:` プレフィックス除去、形式検証の正負例 |
+| `tests/abstract.test.js` | `processAbstract` | JATS タグ処理（実体参照の解除順序・`<jats:title>` 除去・`TITLE:` 変換） |
+| `tests/tsv.test.js` | `generateTsv` | 空配列→`null`、行数、タブ/改行サニタイズ、`repoHost` によるスキーマ URL 置換 |
+| `tests/aff-misattribution.test.js` | `detectAffMisattribution` / `canonicalRor` / `affStringSupportsInst` / `warnTooltip` | 所属誤判定（[#186](https://github.com/tzhaya/jc-import-file-maker/issues/186) 実例）、頭字語裏付けによる誤検出抑制、ROR 正規化 |
+
+**テスト対象は `chrome-extension/*.js` を `require` します。** そのため両ファイル末尾には Node から読み込むための以下の“テスト用ブロック”が恒常的に存在します。**本番 HTML からの同期時に削除しないでください**（ブラウザでは `typeof module === 'undefined'`／`typeof document !== 'undefined'` により無害）:
+
+- 先頭 CONFIG フォールバックの `typeof window !== 'undefined'` ガード
+- DOM 配線・初期化 IIFE を包む `if (typeof document !== 'undefined') { … }` ガード
+- 末尾の `if (typeof module !== 'undefined' && module.exports) { module.exports = { … }; }`
+
+`generateTsv` は `TSV_HEADERS_TEMPLATE` をグローバル参照するため、`tests/tsv.test.js` は `data/tsv_headers.json`（CI でテンプレートと**構造一致**が保証済）を `global.TSV_HEADERS_TEMPLATE` に注入して実テンプレートを供給します。
 
 ### devDependencies（playwright）について
 

--- a/docs/worklog.md
+++ b/docs/worklog.md
@@ -1,6 +1,39 @@
 # 作業ログ: make_jc_importer.html 実装記録
 
-最終更新: 2026-07-05（Codexによる現状レビューを docs に保存）
+最終更新: 2026-07-05（純粋関数の単体テストを追加 #192）
+
+## 純粋関数の単体テストを追加（node:test）（2026-07-05・#192）
+
+### 概要
+CI（`npm test` → `scripts/check.js`）は JSON構文・JS構文・UTF-8妥当性・ファイル同期のみを検証しており、ロジックの振る舞いを検証していなかった。依存ゼロの Node 組み込み `node:test` + `node:assert` を使い、DOM に依存しない純粋関数の単体テストを `tests/` に整備し、`npm test`（CI含む）に組み込んだ。テスト基盤の立ち上げが目的で、対象は副作用のない関数に絞った。
+
+### 実装のポイント（Node から `require` できるようにするガード）
+`chrome-extension/*.js` はブラウザ前提でトップレベルに DOM 配線・`window.*` 書込みがあり、そのままでは Node から `require` すると即例外になる。ブラウザ動作を変えずに require 可能にするため、以下のガードを `chrome-extension/make_jc_importer.js`・`openalex_panel.js` に追加した（HTML 側にはガード/exportは複製しない方針）:
+- 先頭 CONFIG／TSV_HEADERS_TEMPLATE フォールバックの `window.*` 書込みに `typeof window !== 'undefined'` を前置
+- DOM 配線・初期化 IIFE（`init`/`checkForUpdate` 等）を `if (typeof document !== 'undefined') { … }` で包む。**関数宣言はホイストのためガード外（トップレベル）に残し、実行文のみを包む**（sloppy モードのブロック内関数宣言の Annex B 依存を回避）
+- 末尾に `if (typeof module !== 'undefined' && module.exports) { module.exports = { … }; }`
+
+`generateTsv` は `TSV_HEADERS_TEMPLATE` をグローバル遅延参照するため、`tests/tsv.test.js` は `data/tsv_headers.json`（CI でテンプレートと構造一致が保証済）を `global.TSV_HEADERS_TEMPLATE` に注入して実テンプレートを供給する。
+
+### 併せて実施した実挙動変更
+`make_jc_importer` の `normalizeDoi` を `funder_lookup` に合わせ `https://dx.doi.org/…` 対応へ統一（`/^https?:\/\/doi\.org\//i` → `/^https?:\/\/(dx\.)?doi\.org\//i`）。本番HTMLの実挙動が変わるため E2E 対象。
+
+### テスト（31ケース）
+- `tests/doi.test.js`: `normalizeDoi`（URL・`dx.doi.org`・`doi:`・空白）／`isValidDoi`（登録者コード4桁未満・正規化前URL等の負例）
+- `tests/abstract.test.js`: `processAbstract`（実体参照の解除順序・先頭`<jats:title>`除去・`<jats:sec>`内`TITLE:`変換・タグ除去）
+- `tests/tsv.test.js`: `generateTsv`（空配列→`null`・行数・タブ/改行サニタイズ・`repoHost`スキーマURL置換）
+- `tests/aff-misattribution.test.js`: `detectAffMisattribution`（#186 JIRCAS実例で⚠／頭字語裏付けで抑制／bare ID正規化一致）・`canonicalRor`・`affStringSupportsInst`・`warnTooltip`
+
+### 変更ファイル
+- `chrome-extension/make_jc_importer.js`（ガード＋`normalizeDoi`統一＋`module.exports`＋LOCAL_VERSION）
+- `chrome-extension/openalex_panel.js`（ガード＋`module.exports`）
+- `make_jc_importer.html` / `make_jc_importer_test.html`（`normalizeDoi`統一のみ）＋最終更新・更新概要・LOCAL_VERSION
+- `chrome-extension/panel.html`（更新概要）・`chrome-extension/manifest.json`（`1.19.0`→`1.19.1`）
+- `package.json`（`test` に `node --test "tests/**/*.test.js"` を追加）・`scripts/check.js`（テストファイルを検査対象へ）
+- `tests/`（新規4ファイル）・`docs/developer_docs.md`（ユニットテスト節・同期保持ブロックの明記）
+
+### 検証
+`npm test` で `scripts/check.js` ALL PASS＋`node --test` 31ケース ALL PASS（exit 0）。`node -e "require(...)"` で両ファイルが例外なくロードされ期待どおりのエクスポートを確認。E2E は `/e2e-test`（`https://dx.doi.org/…` 入力を含むメインフロー）で確認。
 
 ## Codexによる現状レビューの保存（2026-07-05）
 

--- a/make_jc_importer.html
+++ b/make_jc_importer.html
@@ -490,7 +490,7 @@
 
 <div style="font-size:0.85em; color:#555; background:#f9f9f9; border:1px solid #ddd; border-radius:6px; padding:8px 14px; margin-bottom:12px;">
   <div style="margin-bottom:6px;">
-    <strong>最終更新:</strong> 2026-07-04 &nbsp;|&nbsp;
+    <strong>最終更新:</strong> 2026-07-05 &nbsp;|&nbsp;
     <strong>最新版:</strong> <a href="https://github.com/tzhaya/jc-import-file-maker" target="_blank" style="color:#2c5f2e;">github.com/tzhaya/jc-import-file-maker</a>
     <span id="update-check"></span>
   </div>
@@ -502,6 +502,10 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-07-05</td>
+        <td style="padding:2px 0;">DOI入力の正規化が <code>https://dx.doi.org/…</code> 形式にも対応（従来の <code>https://doi.org/…</code>・<code>doi:…</code> に加えて）（#192）。あわせて純粋関数の単体テスト基盤（node:test）を整備（Chrome拡張 ver. 1.19.1 と同期）</td>
+      </tr>
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-07-04</td>
         <td style="padding:2px 0;">DataCite DOIパスにOPF連動によるアクセス権エンバーゴ判定を追加。OAステータスがclosed/未収録の場合にOPFエンバーゴの有無でembargoed access/open accessを判定（Crossref/JaLCパスと同様）（#214）（Chrome拡張 ver. 1.19.0 と同期）</td>
@@ -517,10 +521,6 @@
       <tr>
         <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-07-02</td>
         <td style="padding:2px 0;">DOIリスト一括取得の実行中に「中断」ボタンを表示し、押下でループを安全に停止できるように（中断前までの成功分は蓄積アイテムに保持）（#194）（Chrome拡張 ver. 1.16.0 と同期）</td>
-      </tr>
-      <tr>
-        <td style="padding:2px 10px 2px 0; white-space:nowrap; vertical-align:top;">2026-06-28</td>
-        <td style="padding:2px 0;">DOIリストの一括取得を追加（複数DOIをまとめて取得→バッチ蓄積）（#154）。OpenAlex機関別著作検索（自機関RORで候補論文を検索しDOIリストを出力、標準版は openalex_lookup.html）を追加（#155）。タイトルのタグ片・改行を除去しTSVの行崩れを防止（#154/#155/#156）（Chrome拡張 ver. 1.14.0 と同期）</td>
       </tr>
     </tbody>
   </table>
@@ -1529,7 +1529,7 @@ function renderSystemFields(systemData) {
 // ===== DOI 正規化 =====
 function normalizeDoi(raw) {
   return raw.trim()
-    .replace(/^https?:\/\/doi\.org\//i, '')
+    .replace(/^https?:\/\/(dx\.)?doi\.org\//i, '')
     .replace(/^doi:/i, '')
     .trim();
 }
@@ -7723,7 +7723,7 @@ function restoreDraft() {
 
 // ===== 更新チェック =====
 (async function checkForUpdate() {
-  const LOCAL_VERSION = '2026-07-04';
+  const LOCAL_VERSION = '2026-07-05';
   try {
     const res = await fetch('https://api.github.com/repos/tzhaya/jc-import-file-maker/commits?path=make_jc_importer.html&per_page=1');
     if (!res.ok) return;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "node scripts/check.js"
+    "test": "node scripts/check.js && node --test \"tests/**/*.test.js\""
   },
   "repository": {
     "type": "git",

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -29,6 +29,11 @@ const JS_FILES = [
   'chrome-extension/options.js',
   'chrome-extension/shared.js',
   'chrome-extension/tsv_headers_template.js',
+  // ユニットテスト（#192）
+  'tests/doi.test.js',
+  'tests/abstract.test.js',
+  'tests/tsv.test.js',
+  'tests/aff-misattribution.test.js',
 ];
 
 // Text files that may contain Japanese — verify no encoding corruption (#175)

--- a/tests/abstract.test.js
+++ b/tests/abstract.test.js
@@ -1,0 +1,49 @@
+'use strict';
+// #192: 抄録 JATS 処理の単体テスト（node:test）
+// 対象: chrome-extension/make_jc_importer.js の processAbstract
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { processAbstract } = require('../chrome-extension/make_jc_importer.js');
+
+test('processAbstract: 空入力は空文字', () => {
+  assert.strictEqual(processAbstract(''), '');
+  assert.strictEqual(processAbstract(null), '');
+  assert.strictEqual(processAbstract(undefined), '');
+});
+
+test('processAbstract: 先頭の <jats:title> は削除される', () => {
+  assert.strictEqual(
+    processAbstract('<jats:title>Abstract</jats:title><jats:p>Body text.</jats:p>'),
+    'Body text.'
+  );
+});
+
+test('processAbstract: <jats:sec> 内の <jats:title> は "TITLE: " 形式へ変換', () => {
+  // 先頭 title は削除、以降の title は "見出し: " に変換される
+  const raw = '<jats:title>Main</jats:title>'
+    + '<jats:sec><jats:title>Methods</jats:title><jats:p>We did X.</jats:p></jats:sec>';
+  assert.strictEqual(processAbstract(raw), 'Methods: We did X.');
+});
+
+test('processAbstract: エスケープされた実体参照を解除（順序依存）', () => {
+  // &lt;jats:p&gt; はまず < > へ解除され、その後タグとして除去される
+  assert.strictEqual(
+    processAbstract('&lt;jats:p&gt;Hello &amp; goodbye&lt;/jats:p&gt;'),
+    'Hello & goodbye'
+  );
+});
+
+test('processAbstract: 改行を除去し連続スペースを1つに正規化', () => {
+  assert.strictEqual(
+    processAbstract('<jats:p>Line one.\n\nLine two.</jats:p>'),
+    'Line one.Line two.'
+  );
+});
+
+test('processAbstract: 残存する全タグを除去', () => {
+  assert.strictEqual(
+    processAbstract('<jats:p>a<jats:italic>b</jats:italic>c</jats:p>'),
+    'abc'
+  );
+});

--- a/tests/aff-misattribution.test.js
+++ b/tests/aff-misattribution.test.js
@@ -1,0 +1,87 @@
+'use strict';
+// #192: 所属誤判定（#186）の単体テスト（node:test）
+// 対象: chrome-extension/openalex_panel.js の
+//   detectAffMisattribution / canonicalRor / affStringSupportsInst / warnTooltip
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  detectAffMisattribution,
+  canonicalRor,
+  affStringSupportsInst,
+  warnTooltip,
+} = require('../chrome-extension/openalex_panel.js');
+
+const JIRCAS_ROR = 'https://ror.org/005pdtr14';
+const JIRCAS_ID = 'https://openalex.org/I0000JIRCAS';
+const JIRCAS_NAME = 'Japan International Research Center for Agricultural Sciences';
+
+// 検索機関(JIRCAS)が著者に付与されているが、所属表記は別機関を指す（#186 実例）
+function workWith(rawAffiliation) {
+  return {
+    authorships: [{
+      author: { display_name: 'Taro Yamada' },
+      institutions: [{ id: JIRCAS_ID, ror: JIRCAS_ROR, display_name: JIRCAS_NAME }],
+      affiliations: [{ institution_ids: [JIRCAS_ID], raw_affiliation_string: rawAffiliation }],
+    }],
+  };
+}
+
+test('canonicalRor: フル URL・bare ID・末尾スラッシュ・大文字を同一に正規化', () => {
+  assert.strictEqual(canonicalRor('https://ror.org/005pdtr14'), '005pdtr14');
+  assert.strictEqual(canonicalRor('005pdtr14'), '005pdtr14');
+  assert.strictEqual(canonicalRor('ror.org/005pdtr14/'), '005pdtr14');
+  assert.strictEqual(canonicalRor('HTTPS://ROR.ORG/005PDTR14'), '005pdtr14');
+  assert.strictEqual(canonicalRor(''), '');
+  assert.strictEqual(canonicalRor(null), '');
+});
+
+test('affStringSupportsInst: 頭字語(JIRCAS)が表記にあれば裏付けありと判定', () => {
+  assert.strictEqual(affStringSupportsInst(JIRCAS_NAME, 'JIRCAS, Tsukuba, Japan'), true);
+});
+
+test('affStringSupportsInst: 弱語(Japan)だけの一致では裏付けなし', () => {
+  assert.strictEqual(affStringSupportsInst(JIRCAS_NAME, 'Hokkaido University, Sapporo, Japan'), false);
+});
+
+test('detectAffMisattribution: 所属表記が別機関 → 警告オブジェクトを返す（#186）', () => {
+  const warn = detectAffMisattribution(workWith('Hokkaido University, Sapporo, Japan'), JIRCAS_ROR);
+  assert.notStrictEqual(warn, null);
+  assert.strictEqual(warn.instName, JIRCAS_NAME);
+  assert.deepStrictEqual(warn.authors, ['Taro Yamada']);
+  assert.strictEqual(warn.repRaw, 'Hokkaido University, Sapporo, Japan');
+  assert.strictEqual(warn.rawCount, 1);
+});
+
+test('detectAffMisattribution: 頭字語(JIRCAS)の裏付けがあれば null（誤検出抑制）', () => {
+  const warn = detectAffMisattribution(workWith('JIRCAS, Tsukuba, Japan'), JIRCAS_ROR);
+  assert.strictEqual(warn, null);
+});
+
+test('detectAffMisattribution: bare ID 指定でも ROR 正規化一致で判定される', () => {
+  const warn = detectAffMisattribution(workWith('Hokkaido University, Sapporo, Japan'), '005pdtr14');
+  assert.notStrictEqual(warn, null);
+});
+
+test('detectAffMisattribution: 検索機関が論文に出現しなければ null', () => {
+  const other = {
+    authorships: [{
+      author: { display_name: 'Hanako Suzuki' },
+      institutions: [{ id: 'https://openalex.org/I999', ror: 'https://ror.org/00000000x', display_name: 'Other Univ' }],
+      affiliations: [{ institution_ids: ['https://openalex.org/I999'], raw_affiliation_string: 'Other University' }],
+    }],
+  };
+  assert.strictEqual(detectAffMisattribution(other, JIRCAS_ROR), null);
+});
+
+test('detectAffMisattribution: searchRor が空なら null', () => {
+  assert.strictEqual(detectAffMisattribution(workWith('X'), ''), null);
+});
+
+test('warnTooltip: 警告オブジェクトから機関名と代表表記を含む文言を組み立てる', () => {
+  const warn = detectAffMisattribution(workWith('Hokkaido University, Sapporo, Japan'), JIRCAS_ROR);
+  const tip = warnTooltip(warn);
+  assert.ok(tip.includes(JIRCAS_NAME));
+  assert.ok(tip.includes('Hokkaido University'));
+  assert.ok(tip.includes('Taro Yamada'));
+});

--- a/tests/doi.test.js
+++ b/tests/doi.test.js
@@ -1,0 +1,56 @@
+'use strict';
+// #192: DOI 正規化・検証の単体テスト（node:test）
+// 対象: chrome-extension/make_jc_importer.js の normalizeDoi / isValidDoi
+// normalizeDoi は #192 で funder_lookup.js に合わせ dx.doi.org 対応へ統一済み。
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { normalizeDoi, isValidDoi } = require('../chrome-extension/make_jc_importer.js');
+
+test('normalizeDoi: https://doi.org/ プレフィックスを除去', () => {
+  assert.strictEqual(normalizeDoi('https://doi.org/10.1016/j.foo.2025.001'), '10.1016/j.foo.2025.001');
+});
+
+test('normalizeDoi: http://dx.doi.org/ プレフィックスを除去（#192 統一）', () => {
+  assert.strictEqual(normalizeDoi('http://dx.doi.org/10.1016/j.foo.2025.001'), '10.1016/j.foo.2025.001');
+});
+
+test('normalizeDoi: https://dx.doi.org/ プレフィックスを除去（#192 統一）', () => {
+  assert.strictEqual(normalizeDoi('https://dx.doi.org/10.1/x'), '10.1/x');
+});
+
+test('normalizeDoi: doi: プレフィックス（大文字含む）を除去', () => {
+  assert.strictEqual(normalizeDoi('DOI:10.1/x'), '10.1/x');
+  assert.strictEqual(normalizeDoi('doi:10.1/x'), '10.1/x');
+});
+
+test('normalizeDoi: 前後の空白を除去', () => {
+  assert.strictEqual(normalizeDoi('  10.1/x  '), '10.1/x');
+});
+
+test('normalizeDoi: 素の DOI はそのまま', () => {
+  assert.strictEqual(normalizeDoi('10.1016/j.advnut.2025.100480'), '10.1016/j.advnut.2025.100480');
+});
+
+test('isValidDoi: 正しい DOI 形式を受理', () => {
+  assert.strictEqual(isValidDoi('10.1016/j.advnut.2025.100480'), true);
+  assert.strictEqual(isValidDoi('10.1234/x'), true);
+});
+
+test('isValidDoi: 不正な値を拒否', () => {
+  assert.strictEqual(isValidDoi('not-a-doi'), false);
+  assert.strictEqual(isValidDoi('10.1/x'), false);         // 登録者コードが4桁未満
+  assert.strictEqual(isValidDoi('10.1234'), false);        // スラッシュ以降なし
+  assert.strictEqual(isValidDoi('https://doi.org/10.1234/x'), false); // 正規化前は不可
+  assert.strictEqual(isValidDoi(''), false);
+  assert.strictEqual(isValidDoi(null), false);
+  assert.strictEqual(isValidDoi(12345), false);
+});
+
+test('isValidDoi: 256 文字超を拒否', () => {
+  assert.strictEqual(isValidDoi('10.1234/' + 'a'.repeat(300)), false);
+});
+
+test('normalizeDoi → isValidDoi: dx.doi.org URL 入力が統一後に検証を通る（#192 実挙動）', () => {
+  assert.strictEqual(isValidDoi(normalizeDoi('https://dx.doi.org/10.1016/j.foo.2025.001')), true);
+});

--- a/tests/tsv.test.js
+++ b/tests/tsv.test.js
@@ -1,0 +1,73 @@
+'use strict';
+// #192: TSV 生成の単体テスト（node:test）
+// 対象: chrome-extension/make_jc_importer.js の generateTsv
+//
+// generateTsv は TSV_HEADERS_TEMPLATE をグローバル参照する（遅延参照）。
+// Node では実テンプレート data/tsv_headers.json を global に注入して供給する。
+// data/tsv_headers.json は CI（scripts/check.js）でテンプレートと構造一致が保証済。
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// require より前に注入しておく（generateTsv は呼び出し時参照なので前後どちらでも可だが明示的に前へ）
+global.TSV_HEADERS_TEMPLATE = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'data', 'tsv_headers.json'), 'utf8')
+);
+
+const { generateTsv } = require('../chrome-extension/make_jc_importer.js');
+
+function sampleMetadata(overrides = {}) {
+  return {
+    system: { doi: '10.1/x', pubdate: '2026-01-01' },
+    item_30002_title0: [{ subitem_title: 'Sample Title', subitem_title_language: 'en' }],
+    ...overrides,
+  };
+}
+
+test('generateTsv: 空配列は null', () => {
+  assert.strictEqual(generateTsv([]), null);
+});
+
+test('generateTsv: 単一 metadata は 5 ヘッダ行 + 1 データ行（末尾改行）', () => {
+  const tsv = generateTsv([sampleMetadata()], '', '');
+  const lines = tsv.split('\n');
+  // 末尾に改行が付くため split で最後に空要素が1つ入る → 5 + 1 + 1(空)
+  assert.strictEqual(lines[lines.length - 1], '');
+  assert.strictEqual(lines.length, 7);
+});
+
+test('generateTsv: N 件で 5 + N データ行', () => {
+  const tsv = generateTsv([sampleMetadata(), sampleMetadata(), sampleMetadata()], '', '');
+  const lines = tsv.replace(/\n$/, '').split('\n');
+  assert.strictEqual(lines.length, 5 + 3);
+});
+
+test('generateTsv: セル内のタブ・改行はサニタイズされ列崩れを起こさない', () => {
+  const tsv = generateTsv(
+    [sampleMetadata({ item_30002_title0: [{ subitem_title: 'A\tB\nC', subitem_title_language: 'en' }] })],
+    '', ''
+  );
+  const lines = tsv.replace(/\n$/, '').split('\n');
+  const header = lines[0].split('\t');
+  // 全データ行がヘッダと同じ列数（タブが混入していない）
+  for (const line of lines) {
+    assert.strictEqual(line.split('\t').length, header.length);
+  }
+  // タブ・改行はスペースに置換されている
+  assert.ok(tsv.includes('A B C'));
+});
+
+test('generateTsv: repoHost でスキーマ URL の localhost を置換', () => {
+  const tsv = generateTsv([sampleMetadata()], '', 'https://repo.example.jp/');
+  const firstRow = tsv.split('\n')[0];
+  assert.ok(firstRow.includes('repo.example.jp'));
+  assert.ok(!firstRow.includes('localhost'));
+});
+
+test('generateTsv: repoHost 未指定なら既定の localhost スキーマ URL のまま', () => {
+  const tsv = generateTsv([sampleMetadata()], '', '');
+  const firstRow = tsv.split('\n')[0];
+  assert.ok(firstRow.includes('localhost'));
+});


### PR DESCRIPTION
## 概要

依存ゼロの Node 組み込み `node:test` + `node:assert` を使い、DOM に依存しない純粋関数の単体テストを `tests/` に整備し、`npm test`（CI含む）に組み込みました（[#192](https://github.com/tzhaya/jc-import-file-maker/issues/192)）。これまで CI はJSON構文・JS構文・UTF-8妥当性・ファイル同期のみでロジックの振る舞いを検証していませんでした。

Issue のレビューコメント（実装方針・レビュー反映版）に沿って実装し、着手前レビューで指摘した点（バージョン/行番号の再採番・ガード範囲の最小化・「構造一致」の正確な記述・同期保持ブロックの明記）も反映しています。

## 変更内容

### テスト基盤（31ケース）
- `tests/doi.test.js` — `normalizeDoi` / `isValidDoi`
- `tests/abstract.test.js` — `processAbstract`（JATSタグ処理）
- `tests/tsv.test.js` — `generateTsv`（空配列→null・行数・タブ/改行サニタイズ・repoHost置換）
- `tests/aff-misattribution.test.js` — `detectAffMisattribution`（#186 JIRCAS実例）・`canonicalRor`・`affStringSupportsInst`・`warnTooltip`

### Node から require するためのガード（ブラウザ動作は不変）
`chrome-extension/make_jc_importer.js`・`openalex_panel.js` に追加（HTML側には複製しない方針）:
- 先頭 CONFIG／TSV_HEADERS_TEMPLATE フォールバックの `window.*` 書込みに `typeof window` を前置
- DOM 配線・初期化 IIFE を `if (typeof document !== 'undefined')` で包む（**関数宣言はホイストのためガード外に残し実行文のみ**）
- 末尾に `if (typeof module !== 'undefined' && module.exports) { module.exports = {...}; }`

`generateTsv` は `TSV_HEADERS_TEMPLATE` をグローバル遅延参照するため、テストは `data/tsv_headers.json`（CIで構造一致が保証済）を `global` に注入して供給します。

### 併せて実施した実挙動変更
- `make_jc_importer` の `normalizeDoi` を `funder_lookup` に合わせ `https://dx.doi.org/…` 対応へ統一（`/^https?:\/\/doi\.org\//i` → `/^https?:\/\/(dx\.)?doi\.org\//i`）。requirements.md が既に `dx.doi.org` を記載しており、実装が仕様に追随する形です。

### 同期・バージョン
- `manifest.json` `1.19.0` → `1.19.1`、`LOCAL_VERSION` `2026-07-05`、最終更新日・更新概要テーブル（`make_jc_importer.html`／`chrome-extension/panel.html`）
- `package.json` の `test` に `node --test "tests/**/*.test.js"` を追加、`scripts/check.js` にテストファイルを検査対象として追加
- `docs/developer_docs.md` にユニットテスト節（対象関数一覧・**同期時に消してはいけないブロック**の明記）・README・worklog を更新

## テスト結果

- **`npm test`**: `scripts/check.js` ALL PASS ＋ `node:test` 31ケース ALL PASS（exit 0）
- **`/e2e-test`（main）ALL PASSED**:
  - 素のDOI `10.1016/j.advnut.2025.100480`（回帰）
  - **`https://dx.doi.org/10.1016/j.advnut.2025.100480`（#192の実挙動変更を検証）** — 正しく正規化されデータ取得・DOIリンク解決を確認
  - funder連携（検出課題番号 JP19KK0341）

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)